### PR TITLE
fix(pods): set containerPort to 23001 in worker-pod.yaml

### DIFF
--- a/pods/worker-pod.yaml
+++ b/pods/worker-pod.yaml
@@ -24,7 +24,7 @@ spec:
     - name: worker
       image: achaean-worker:latest
       ports:
-        - containerPort: 23080
+        - containerPort: 23001
           hostPort: 23080
           protocol: TCP
       env:


### PR DESCRIPTION
## Summary

- `containerPort` in `pods/worker-pod.yaml` was incorrectly set to `23080`, but the container process listens on `AGENT_PORT` which defaults to `23001`
- Fixed `containerPort` to `23001` while keeping `hostPort` at `23080` (the worker's assigned external port per the port mapping convention)

## Test plan

- [ ] Verify `podman play kube pods/worker-pod.yaml` succeeds
- [ ] Confirm traffic on host port 23080 is correctly forwarded to container port 23001
- [ ] Check worker agent responds to requests through the pod

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)