### PR TITLE
fix(compose): correct agent count and unassigned port labels

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,10 +69,10 @@ volumes:
 ```
 8080      ProjectAgamemnon coordinator (existing, not in this repo)
 23001     hi-aindrea (claude)
-23002     (reserved)
+23002     (unassigned)
 23003     hi-baird (claude)
 23004     hi-vegai (claude)
-23005     (reserved)
+23005     (unassigned)
 23010     hi-codex-1
 23020     hi-aider-1
 23030     hi-goose-1

--- a/compose/docker-compose.claude-only.yml
+++ b/compose/docker-compose.claude-only.yml
@@ -1,6 +1,6 @@
 # AchaeanFleet: Claude-only Compose
 #
-# Mirrors the current local setup (5 Claude agents).
+# Mirrors the current local setup (3 Claude agents).
 # This is the Phase 3 verification target: docker compose up starts a Claude
 # container that ProjectAgamemnon connects to via the agent sidecar.
 #


### PR DESCRIPTION
## Summary

- Corrects the `docker-compose.claude-only.yml` header comment from "5 Claude agents" to "3 Claude agents" to match the actual 3 service definitions (`hi-aindrea`, `hi-baird`, `hi-vegai`)
- Updates `CLAUDE.md` port table: ports 23002 and 23005 changed from `(reserved)` to `(unassigned)` since no concrete service definitions exist for them anywhere in the repo

No new services were fabricated — there is no authoritative source for what the "missing" 2 agents' identities or workspaces would be. The fix chooses documentation accuracy over speculative placeholders.

## Test plan

- [x] Compose YAML header comment matches actual service count (3)
- [x] `CLAUDE.md` port table accurately describes current state (unassigned vs reserved)
- [x] No YAML syntax changes — only a comment line was modified in the compose file

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)