### PR TITLE
fix(dispatch): route notify-proteus.sh through ProjectProteus, add host field

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,3 +145,11 @@ jobs:
         env:
           DAGGER_REGISTRY: ghcr.io/homericintelligence
         run: npx ts-node dagger/pipeline.ts push --registry "$DAGGER_REGISTRY"
+
+      - name: Notify ProjectProteus of image push
+        env:
+          GITHUB_TOKEN: ${{ secrets.DISPATCH_TOKEN }}
+          GITHUB_ORG: homericintelligence
+          IMAGE_TAG: ${{ github.sha }}
+          AGAMEMNON_HOST: hermes
+        run: bash scripts/notify-proteus.sh

--- a/scripts/notify-proteus.sh
+++ b/scripts/notify-proteus.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # notify-proteus.sh — Notify ProjectProteus that images were pushed.
-# Triggers a repository_dispatch to Myrmidons via ProjectProteus.
-# Called by: just push-and-notify
+# Dispatch chain: AchaeanFleet → ProjectProteus (image-pushed)
+#                 → Myrmidons (agamemnon-apply) via Proteus cross-repo-dispatch.yml
+# Called by: just push-and-notify, ci.yml push-to-registry job
 set -euo pipefail
 
 GITHUB_TOKEN=${GITHUB_TOKEN:-}
-ORG=${GITHUB_ORG:-homeric-intelligence}
-REPO=${NOTIFY_REPO:-Myrmidons}
+ORG=${GITHUB_ORG:-homericintelligence}
+REPO=${NOTIFY_REPO:-ProjectProteus}
 IMAGE_TAG=${IMAGE_TAG:-latest}
+HOST=${AGAMEMNON_HOST:-hermes}
 
 if [ -z "$GITHUB_TOKEN" ]; then
     echo "GITHUB_TOKEN not set — skipping remote dispatch"
@@ -21,7 +23,7 @@ response=$(curl -sf -o /dev/null -w "%{http_code}" \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
     "https://api.github.com/repos/${ORG}/${REPO}/dispatches" \
-    -d "{\"event_type\": \"image-pushed\", \"client_payload\": {\"image_tag\": \"${IMAGE_TAG}\", \"source\": \"AchaeanFleet\"}}")
+    -d "{\"event_type\": \"image-pushed\", \"client_payload\": {\"image_tag\": \"${IMAGE_TAG}\", \"source\": \"AchaeanFleet\", \"host\": \"${HOST}\"}}")
 
 if [ "$response" = "204" ]; then
     echo "Dispatch sent successfully (HTTP 204)"

--- a/tests/notify-proteus.bats
+++ b/tests/notify-proteus.bats
@@ -1,0 +1,151 @@
+#!/usr/bin/env bats
+# Tests for scripts/notify-proteus.sh
+#
+# Dispatch chain under test:
+#   AchaeanFleet → ProjectProteus (image-pushed)
+#                → Myrmidons (agamemnon-apply) via Proteus cross-repo-dispatch.yml
+
+SCRIPT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)/scripts/notify-proteus.sh"
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+# Installs a mock `curl` on PATH that records its arguments to CURL_ARGS_FILE
+# and returns a configurable HTTP status code (default 204).
+setup_mock_curl() {
+    local http_code="${1:-204}"
+    export CURL_ARGS_FILE="$(mktemp)"
+    export MOCK_HTTP_CODE="$http_code"
+
+    export MOCK_BIN="$(mktemp -d)"
+    cat > "$MOCK_BIN/curl" <<EOF
+#!/usr/bin/env bash
+echo "\$@" > "$CURL_ARGS_FILE"
+echo "$http_code"
+EOF
+    chmod +x "$MOCK_BIN/curl"
+    export PATH="$MOCK_BIN:$PATH"
+}
+
+teardown() {
+    [[ -n "${CURL_ARGS_FILE:-}" && -f "$CURL_ARGS_FILE" ]] && rm -f "$CURL_ARGS_FILE"
+    [[ -n "${MOCK_BIN:-}" && -d "$MOCK_BIN" ]]             && rm -rf "$MOCK_BIN"
+    return 0
+}
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+@test "missing GITHUB_TOKEN exits 0 with skip message" {
+    run env -i PATH="$PATH" GITHUB_TOKEN="" bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GITHUB_TOKEN not set"* ]]
+}
+
+@test "unset GITHUB_TOKEN also exits 0 with skip message" {
+    run bash -c "unset GITHUB_TOKEN; bash '$SCRIPT'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"GITHUB_TOKEN not set"* ]]
+}
+
+@test "dispatches to ProjectProteus by default" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "ProjectProteus" "$CURL_ARGS_FILE"
+}
+
+@test "NOTIFY_REPO override is respected" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token NOTIFY_REPO=SomeOtherRepo bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "SomeOtherRepo" "$CURL_ARGS_FILE"
+}
+
+@test "does NOT dispatch to Myrmidons by default" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    ! grep -q "Myrmidons" "$CURL_ARGS_FILE"
+}
+
+@test "client_payload contains host field" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q '"host"' "$CURL_ARGS_FILE"
+}
+
+@test "AGAMEMNON_HOST default is hermes" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q '"host": "hermes"' "$CURL_ARGS_FILE"
+}
+
+@test "AGAMEMNON_HOST override is passed in payload" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token AGAMEMNON_HOST=custom-host bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q '"host": "custom-host"' "$CURL_ARGS_FILE"
+}
+
+@test "client_payload contains image_tag field" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token IMAGE_TAG=sha-abc123 bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q '"image_tag": "sha-abc123"' "$CURL_ARGS_FILE"
+}
+
+@test "IMAGE_TAG defaults to latest when not set" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q '"image_tag": "latest"' "$CURL_ARGS_FILE"
+}
+
+@test "client_payload contains source field set to AchaeanFleet" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q '"source": "AchaeanFleet"' "$CURL_ARGS_FILE"
+}
+
+@test "event_type is image-pushed" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q '"event_type": "image-pushed"' "$CURL_ARGS_FILE"
+}
+
+@test "HTTP 204 response exits 0" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"successfully"* ]]
+}
+
+@test "non-204 response exits 1" {
+    setup_mock_curl 422
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Dispatch failed"* ]]
+}
+
+@test "HTTP 404 response exits 1" {
+    setup_mock_curl 404
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 1 ]
+}
+
+@test "uses homericintelligence org by default" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "homericintelligence" "$CURL_ARGS_FILE"
+}
+
+@test "GITHUB_ORG override is respected" {
+    setup_mock_curl 204
+    run env GITHUB_TOKEN=test-token GITHUB_ORG=myorg bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    grep -q "myorg" "$CURL_ARGS_FILE"
+}


### PR DESCRIPTION
## Summary

- Change `NOTIFY_REPO` default from `Myrmidons` → `ProjectProteus` so `notify-proteus.sh` honours its name and the canonical dispatch chain: AchaeanFleet → ProjectProteus (`image-pushed`) → Myrmidons (`agamemnon-apply`) via `cross-repo-dispatch.yml`
- Fix `GITHUB_ORG` default casing: `homeric-intelligence` → `homericintelligence` (relates to #4)
- Add `HOST` variable (`AGAMEMNON_HOST`, default `hermes`) and include it in `client_payload` so ProjectProteus receives the `host` field its `dispatch-apply.sh` requires
- Wire `notify-proteus.sh` into the `push-to-registry` CI job via `secrets.DISPATCH_TOKEN` (note: `GITHUB_TOKEN` cannot trigger cross-repo dispatches — `DISPATCH_TOKEN` must be added to repo secrets as a PAT with `repo` scope on ProjectProteus)
- Add `tests/notify-proteus.bats` with 17 BATS tests

## Test plan

- [x] `bats tests/notify-proteus.bats` — all 17 tests pass
- [ ] Add `DISPATCH_TOKEN` secret to AchaeanFleet repo settings before merging
- [ ] After merge to main: confirm `push-to-registry` job runs the notify step; verify ProjectProteus `cross-repo-dispatch.yml` receives `image-pushed` with `host` field populated

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)