### PR TITLE
fix(security): remove NOPASSWD:ALL sudo from all base Dockerfiles

### DIFF
--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -36,8 +36,7 @@ RUN npm install -g yarn
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN groupadd -g ${GROUP_ID} agent && \
-    useradd -m -u ${USER_ID} -g agent -s /bin/zsh agent && \
-    echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    useradd -m -u ${USER_ID} -g agent -s /bin/zsh agent
 
 # Configure tmux
 RUN mkdir -p /home/agent && \

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -25,13 +25,11 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     build-essential \
     python3 \
-    sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # node:20-slim ships with user 'node' (UID 1000). Rename to 'agent' for convention.
 RUN usermod -l agent -d /home/agent -m node && \
-    groupmod -n agent node && \
-    echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    groupmod -n agent node
 
 # Configure tmux
 RUN mkdir -p /home/agent && \

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -35,8 +35,7 @@ RUN npm install -g yarn
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN groupadd -g ${GROUP_ID} agent && \
-    useradd -m -u ${USER_ID} -g agent -s /bin/zsh agent && \
-    echo "agent ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+    useradd -m -u ${USER_ID} -g agent -s /bin/zsh agent
 
 # Configure tmux
 RUN mkdir -p /home/agent && \


### PR DESCRIPTION
## Summary

- Remove `NOPASSWD:ALL` sudoers entry from `Dockerfile.node`, `Dockerfile.python`, and `Dockerfile.minimal`
- Remove `sudo` package installation from `Dockerfile.node` (only installed to support the now-removed sudoers rule)
- Agent user now has no path to root escalation inside containers

## Why

Any code running in a container (including AI agent-generated code) could previously escalate to root with zero friction. Combined with host filesystem volume mounts, this was a privilege escalation vector from container to host. All operations requiring root already happen in build stages before `USER agent`, so removing runtime sudo access has no functional impact.

## Test plan

- [ ] Build `bases/Dockerfile.node` — verify it builds successfully without `sudo` in the package list
- [ ] Build `bases/Dockerfile.python` — verify it builds successfully
- [ ] Build `bases/Dockerfile.minimal` — verify it builds successfully
- [ ] Run a vessel container and confirm `sudo` commands are denied (or sudo is not present)
- [ ] Confirm existing vessel Dockerfiles do not rely on runtime sudo

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)