### PR TITLE
fix(scripts): use CONTAINER_CMD in build-all.sh instead of hardcoding docker

### DIFF
--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -6,11 +6,13 @@
 #
 # Usage:
 #   bash scripts/build-all.sh
-#   TAG=v1.2.3 bash scripts/build-all.sh   # Override image tag
+#   TAG=v1.2.3 bash scripts/build-all.sh              # Override image tag
+#   CONTAINER_CMD=podman bash scripts/build-all.sh    # Use podman instead of docker
 
 set -euo pipefail
 
 TAG="${TAG:-latest}"
+CONTAINER_CMD="${CONTAINER_CMD:-docker}"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
@@ -29,7 +31,7 @@ build_image() {
 
     echo ""
     echo "--- Building ${tag} from ${dockerfile} ---"
-    if docker build -f "${dockerfile}" -t "${tag}" "${extra_args[@]}" .; then
+    if ${CONTAINER_CMD} build -f "${dockerfile}" -t "${tag}" "${extra_args[@]}" .; then
         echo "    OK: ${tag}"
         built=$((built + 1))
     else


### PR DESCRIPTION
## Summary

- `scripts/build-all.sh` was hardcoding `docker build` on line 32, ignoring the `CONTAINER_CMD` env var passed by `just build-all`
- Added `CONTAINER_CMD="${CONTAINER_CMD:-docker}"` near the top of the script
- Replaced `docker build` with `${CONTAINER_CMD} build` in the `build_image` function
- Added `CONTAINER_CMD` usage to the script's header comment

## Test plan

- [ ] Verify `just build-all` works on a Docker-only system (defaults to `docker`)
- [ ] Verify `just build-all` works on a Podman-only system (justfile auto-detects `podman`, passes it via `CONTAINER_CMD`)
- [ ] Verify `CONTAINER_CMD=podman bash scripts/build-all.sh` works directly

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)