### PR TITLE
fix(security): restrict agent workspace mounts to dedicated subdirectories

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -30,6 +30,16 @@ WORKER_IMAGE=achaean-worker:latest
 # =============================================================================
 # Host workspace mounts
 # =============================================================================
+# WORKSPACE_ROOT is the base directory for all agent workspaces.
+# Each agent mounts a dedicated subdirectory: ${WORKSPACE_ROOT}/Agents/<name>
+# These directories must exist before starting the compose stack.
+#
+# WARNING: Do NOT set WORKSPACE_ROOT to $HOME or any directory containing
+#          SSH keys, GPG keys, or other credentials. Agents only need access
+#          to their own workspace, not the entire home directory.
+#
+# Create agent directories before first run:
+#   mkdir -p ~/Agents/{Vegai,Codex-1,Aider-1,Goose-1,Cline-1,Opencode-1,Codebuff-1,Ampcode-1}
 WORKSPACE_ROOT=/home/mvillmow
 
 # =============================================================================

--- a/compose/docker-compose.claude-only.yml
+++ b/compose/docker-compose.claude-only.yml
@@ -102,7 +102,7 @@ services:
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - AGAMEMNON_URL=${AGAMEMNON_URL:-http://172.20.0.1:8080}
     volumes:
-      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Vegai:/workspace
     working_dir: /workspace
     restart: unless-stopped
     healthcheck:

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -84,7 +84,7 @@ services:
       TMUX_SESSION_NAME: codex-1
       OPENAI_API_KEY: ${OPENAI_API_KEY}
     volumes:
-      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Codex-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
     healthcheck: *healthcheck
@@ -106,7 +106,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
       AIDER_MODEL: ${AIDER_MODEL:-claude-3-5-sonnet-20241022}
     volumes:
-      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Aider-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
     healthcheck: *healthcheck
@@ -127,7 +127,7 @@ services:
       TMUX_SESSION_NAME: goose-1
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     volumes:
-      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Goose-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
     healthcheck: *healthcheck
@@ -148,7 +148,7 @@ services:
       TMUX_SESSION_NAME: cline-1
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     volumes:
-      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Cline-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
     healthcheck: *healthcheck
@@ -169,7 +169,7 @@ services:
       TMUX_SESSION_NAME: opencode-1
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     volumes:
-      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Opencode-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
     healthcheck: *healthcheck
@@ -190,7 +190,7 @@ services:
       TMUX_SESSION_NAME: codebuff-1
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     volumes:
-      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Codebuff-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
     healthcheck: *healthcheck
@@ -211,7 +211,7 @@ services:
       TMUX_SESSION_NAME: ampcode-1
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
     volumes:
-      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Ampcode-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
     healthcheck: *healthcheck


### PR DESCRIPTION
## Summary

- Fixes a CRITICAL POLA violation where 8 agent containers mounted the operator's entire home directory (`/home/mvillmow`) as `/workspace`, exposing SSH keys, GPG keys, `.env` files, and all other sensitive home directory contents to every AI agent
- Each service now mounts only its dedicated `${WORKSPACE_ROOT}/Agents/<name>` subdirectory
- Updated `.env.example` with a security warning and a `mkdir -p` hint for operators

**Services fixed:**
| Service | Before | After |
|---------|--------|-------|
| hi-vegai | `${WORKSPACE_ROOT}:/workspace` | `${WORKSPACE_ROOT}/Agents/Vegai:/workspace` |
| hi-codex-1 | `${WORKSPACE_ROOT}:/workspace` | `${WORKSPACE_ROOT}/Agents/Codex-1:/workspace` |
| hi-aider-1 | `${WORKSPACE_ROOT}:/workspace` | `${WORKSPACE_ROOT}/Agents/Aider-1:/workspace` |
| hi-goose-1 | `${WORKSPACE_ROOT}:/workspace` | `${WORKSPACE_ROOT}/Agents/Goose-1:/workspace` |
| hi-cline-1 | `${WORKSPACE_ROOT}:/workspace` | `${WORKSPACE_ROOT}/Agents/Cline-1:/workspace` |
| hi-opencode-1 | `${WORKSPACE_ROOT}:/workspace` | `${WORKSPACE_ROOT}/Agents/Opencode-1:/workspace` |
| hi-codebuff-1 | `${WORKSPACE_ROOT}:/workspace` | `${WORKSPACE_ROOT}/Agents/Codebuff-1:/workspace` |
| hi-ampcode-1 | `${WORKSPACE_ROOT}:/workspace` | `${WORKSPACE_ROOT}/Agents/Ampcode-1:/workspace` |

Services already correct (`hi-aindrea`, `hi-baird`, `hi-worker-1`) are unchanged.

## Test plan

- [x] Grep confirms no bare `${WORKSPACE_ROOT:-/home/mvillmow}:/workspace` mounts remain in any compose file
- [x] All `/workspace` mounts now include `/Agents/<name>`, `/ProjectScylla`, or `/tmp/ci-workspace`
- [ ] Before running: `mkdir -p ~/Agents/{Vegai,Codex-1,Aider-1,Goose-1,Cline-1,Opencode-1,Codebuff-1,Ampcode-1}`
- [ ] Validate compose YAML: `docker compose -f compose/docker-compose.claude-only.yml config --quiet && docker compose -f compose/docker-compose.mesh.yml config --quiet`

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)