### PR TITLE
fix(security): eliminate curl-pipe-bash supply chain risk in all Dockerfiles

### DIFF
--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -3,14 +3,14 @@
 # Provides: debian:bookworm-slim + Node.js 20 + tmux + zsh + git
 # Binary-based agent vessels (Goose, OpenCode, Worker) FROM this.
 
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:4724b8cc51e33e398f0e2e15e18d5ec2851ff0c2280647e1310bc1642182655d
 
 LABEL org.opencontainers.image.title="achaean-base-minimal"
 LABEL org.opencontainers.image.description="AchaeanFleet minimal Debian base image for AI agent containers"
 LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/AchaeanFleet"
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     wget \
     git \
@@ -24,10 +24,17 @@ RUN apt-get update && apt-get install -y \
     python3 \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 20.x
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
+# Install Node.js 20.x via GPG-signed NodeSource repository (no curl-pipe-bash)
+RUN apt-get update && apt-get install -y gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        -o /tmp/nodesource.gpg.key && \
+    gpg --dearmor < /tmp/nodesource.gpg.key > /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/* /tmp/nodesource.gpg.key
 
 # Install Yarn
 RUN npm install -g yarn
@@ -46,11 +53,6 @@ RUN mkdir -p /home/agent && \
     echo "set -g status-bg colour235" >> /home/agent/.tmux.conf && \
     echo "set -g status-fg colour136" >> /home/agent/.tmux.conf && \
     chown -R agent:agent /home/agent
-
-# Install Oh My Zsh
-USER agent
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-USER root
 
 # Create workspace and app directories
 RUN mkdir -p /workspace /app && \

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -4,7 +4,7 @@
 # Compatible with the HomericIntelligence agent mesh.
 # All node-based agent vessels (Claude, Codex, Cline, Codebuff, AmpCode) FROM this.
 
-FROM node:20-slim
+FROM node:20-slim@sha256:f93745c153377ee2fbbdd6e24efcd03cd2e86d6ab1d8aa9916a3790c40313a55
 
 LABEL org.opencontainers.image.title="achaean-base-node"
 LABEL org.opencontainers.image.description="AchaeanFleet Node.js base image for AI agent containers"
@@ -13,7 +13,7 @@ LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/Ac
 USER root
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     wget \
     git \
@@ -40,11 +40,6 @@ RUN mkdir -p /home/agent && \
     echo "set -g status-bg colour235" >> /home/agent/.tmux.conf && \
     echo "set -g status-fg colour136" >> /home/agent/.tmux.conf && \
     chown -R agent:agent /home/agent
-
-# Install Oh My Zsh
-USER agent
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-USER root
 
 # Create workspace and app directories
 RUN mkdir -p /workspace /app && \

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -3,14 +3,14 @@
 # Provides: python:3.12-slim + Node.js 20 + tmux + zsh + git
 # Python-based agent vessels (Aider) FROM this.
 
-FROM python:3.12-slim
+FROM python:3.12-slim@sha256:804ddf3251a60bbf9c92e73b7566c40428d54d0e79d3428194edf40da6521286
 
 LABEL org.opencontainers.image.title="achaean-base-python"
 LABEL org.opencontainers.image.description="AchaeanFleet Python base image for AI agent containers"
 LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/AchaeanFleet"
 
 # Install system dependencies
-RUN apt-get update && apt-get install -y \
+RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \
     wget \
     git \
@@ -23,10 +23,17 @@ RUN apt-get update && apt-get install -y \
     build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-# Install Node.js 20.x
-RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
-    apt-get install -y nodejs && \
-    rm -rf /var/lib/apt/lists/*
+# Install Node.js 20.x via GPG-signed NodeSource repository (no curl-pipe-bash)
+RUN apt-get update && apt-get install -y gnupg && \
+    mkdir -p /etc/apt/keyrings && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key \
+        -o /tmp/nodesource.gpg.key && \
+    gpg --dearmor < /tmp/nodesource.gpg.key > /etc/apt/keyrings/nodesource.gpg && \
+    echo "deb [signed-by=/etc/apt/keyrings/nodesource.gpg] https://deb.nodesource.com/node_20.x nodistro main" \
+        > /etc/apt/sources.list.d/nodesource.list && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/* /tmp/nodesource.gpg.key
 
 # Install Yarn
 RUN npm install -g yarn
@@ -45,11 +52,6 @@ RUN mkdir -p /home/agent && \
     echo "set -g status-bg colour235" >> /home/agent/.tmux.conf && \
     echo "set -g status-fg colour136" >> /home/agent/.tmux.conf && \
     chown -R agent:agent /home/agent
-
-# Install Oh My Zsh
-USER agent
-RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
-USER root
 
 # Upgrade pip
 RUN pip install --upgrade pip

--- a/vessels/goose/Dockerfile
+++ b/vessels/goose/Dockerfile
@@ -11,13 +11,16 @@ LABEL org.opencontainers.image.description="Goose (Block) AI agent vessel"
 
 USER root
 
-# Install Goose via official install script
-RUN curl -fsSL https://github.com/block/goose/releases/latest/download/install.sh | bash || \
-    curl -fsSL https://github.com/block/goose/releases/latest/download/goose-linux-x86_64.tar.gz \
+# Install Goose — pinned version with SHA256 verification (no curl-pipe-bash)
+ARG GOOSE_VERSION=1.30.0
+ARG GOOSE_SHA256=0aeb220b744208b2fe5eca86eefdd31a4e0a6a35bdd0651ebd29959fc02f9eaf
+RUN curl -fsSL \
+        "https://github.com/block/goose/releases/download/v${GOOSE_VERSION}/goose-x86_64-unknown-linux-gnu.tar.gz" \
         -o /tmp/goose.tar.gz && \
-    tar -xzf /tmp/goose.tar.gz -C /usr/local/bin && \
+    echo "${GOOSE_SHA256}  /tmp/goose.tar.gz" | sha256sum --check && \
+    tar -xzf /tmp/goose.tar.gz -C /usr/local/bin ./goose && \
     chmod +x /usr/local/bin/goose && \
-    rm -f /tmp/goose.tar.gz
+    rm /tmp/goose.tar.gz
 
 # Verify installation
 RUN goose --version || true

--- a/vessels/opencode/Dockerfile
+++ b/vessels/opencode/Dockerfile
@@ -10,16 +10,16 @@ LABEL org.opencontainers.image.description="OpenCode AI coding agent vessel"
 
 USER root
 
-# Install OpenCode via official install script or direct binary download
-RUN curl -fsSL https://opencode.ai/install | bash || \
-    ( \
-        OPENCODE_VERSION=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest | grep '"tag_name"' | sed 's/.*"tag_name": "\(.*\)".*/\1/') && \
-        curl -fsSL "https://github.com/sst/opencode/releases/download/${OPENCODE_VERSION}/opencode_linux_amd64.tar.gz" \
-            -o /tmp/opencode.tar.gz && \
-        tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin && \
-        chmod +x /usr/local/bin/opencode && \
-        rm -f /tmp/opencode.tar.gz \
-    )
+# Install OpenCode — pinned version with SHA256 verification (no curl-pipe-bash)
+ARG OPENCODE_VERSION=1.4.3
+ARG OPENCODE_SHA256=34d503ebb029853293be6fd4d441bbb2dbb03919bfa4525e88b1ca55d68f3e17
+RUN curl -fsSL \
+        "https://github.com/sst/opencode/releases/download/v${OPENCODE_VERSION}/opencode-linux-x64.tar.gz" \
+        -o /tmp/opencode.tar.gz && \
+    echo "${OPENCODE_SHA256}  /tmp/opencode.tar.gz" | sha256sum --check && \
+    tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin opencode && \
+    chmod +x /usr/local/bin/opencode && \
+    rm /tmp/opencode.tar.gz
 
 # Verify installation
 RUN opencode --version || true

--- a/vessels/worker/Dockerfile
+++ b/vessels/worker/Dockerfile
@@ -19,11 +19,16 @@ RUN apt-get update && apt-get install -y \
     make \
     && rm -rf /var/lib/apt/lists/* || true
 
-# Install yq if not available via apt
-RUN which yq || \
-    curl -fsSL "https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64" \
-        -o /usr/local/bin/yq && \
-    chmod +x /usr/local/bin/yq
+# Install yq if not available via apt — pinned version with SHA256 verification (no unverified download)
+ARG YQ_VERSION=4.52.5
+ARG YQ_SHA256=75d893a0d5940d1019cb7cdc60001d9e876623852c31cfc6267047bc31149fa9
+RUN which yq || ( \
+    curl -fsSL \
+        "https://github.com/mikefarah/yq/releases/download/v${YQ_VERSION}/yq_linux_amd64" \
+        -o /tmp/yq && \
+    echo "${YQ_SHA256}  /tmp/yq" | sha256sum --check && \
+    install -m 755 /tmp/yq /usr/local/bin/yq && \
+    rm /tmp/yq )
 
 USER agent
 


### PR DESCRIPTION
## Summary

Fixes OWASP A08:2021 (Software and Data Integrity Failures) by removing all `curl | bash` / `curl | sh` patterns from Dockerfiles and replacing them with integrity-verified alternatives.

- **Pin base image digests**: All `FROM` lines now include `@sha256:<digest>` to prevent mutable-tag hijacking
- **Add `apt-get upgrade -y`**: Defense-in-depth for OS-level CVEs in all base images
- **Node.js installation**: Replace `curl ... nodesource setup_20.x | bash -` with a GPG-signed NodeSource apt repository in `Dockerfile.minimal` and `Dockerfile.python` (Node.js is already provided by `node:20-slim` in `Dockerfile.node`)
- **Remove Oh My Zsh**: Eliminate the `curl | sh` Oh My Zsh installer from all base images — it's a developer convenience with no runtime requirement
- **Goose v1.30.0**: Download tarball directly, verify SHA256 (`0aeb220b...`), extract binary — no install script
- **OpenCode v1.4.3**: Download tarball directly, verify SHA256 (`34d503eb...`), extract binary — no install script
- **yq v4.52.5**: Download binary directly, verify SHA256 (`75d893a0...`), install — no unverified fallback

## Test plan

- [ ] `grep -rn "curl\|wget" bases/ vessels/ | grep -E "\|.*sh\b|\|.*bash\b"` returns no results
- [ ] `docker build -f bases/Dockerfile.node -t achaean-base-node:test .` succeeds
- [ ] `docker build -f bases/Dockerfile.python -t achaean-base-python:test .` succeeds
- [ ] `docker build -f bases/Dockerfile.minimal -t achaean-base-minimal:test .` succeeds
- [ ] `docker build -f vessels/goose/Dockerfile --build-arg BASE_IMAGE=achaean-base-minimal:test -t achaean-goose:test .` succeeds and `goose --version` runs
- [ ] `docker build -f vessels/opencode/Dockerfile --build-arg BASE_IMAGE=achaean-base-minimal:test -t achaean-opencode:test .` succeeds and `opencode --version` runs
- [ ] `docker build -f vessels/worker/Dockerfile --build-arg BASE_IMAGE=achaean-base-minimal:test -t achaean-worker:test .` succeeds and `yq --version` runs
- [ ] Corrupting a SHA256 `ARG` causes the build to fail with a checksum mismatch error

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)