### PR TITLE
fix(gitignore): add .pixi/ entry to prevent committing pixi env cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ Thumbs.db
 # Docker build cache artifacts
 .dockerignore.bak
 
+# Pixi environment cache
+.pixi/
+
 # Local test outputs
 /tmp/


### PR DESCRIPTION
## Summary

- Adds `.pixi/` to `.gitignore` to exclude the local pixi conda environment cache from version control

## Background

The project uses pixi for environment management (`pixi.toml` exists) but `.pixi/` was absent from `.gitignore`. This created a risk of accidentally committing the local environment directory, which would bloat the repository.

## Test plan

- [x] Verified `.pixi/` entry added to `.gitignore`
- [x] Confirmed no other pixi-related entries existed that would conflict
- [x] No code changes — this is a config-only fix

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)