### PR TITLE
feat(dx): add bootstrap recipe for one-command environment setup

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,6 +26,14 @@ compose_cmd := `which podman-compose 2>/dev/null && echo podman-compose || echo 
 # Build
 # =============================================================================
 
+# One-command environment setup for new developers
+bootstrap:
+    @echo "=== AchaeanFleet bootstrap ==="
+    @test -f compose/.env || cp compose/.env.example compose/.env && echo "Created compose/.env -- edit API keys"
+    @cd dagger && npm install
+    @just runtime
+    @echo "=== Ready. Edit compose/.env then run: just build-all ==="
+
 # Show which container runtime is active
 runtime:
     @echo "Container runtime: {{container_cmd}}"


### PR DESCRIPTION
## Summary

- Adds a `just bootstrap` recipe to `justfile` that handles the full developer onboarding flow in one command
- Copies `compose/.env.example` → `compose/.env` if not already present (with a reminder to edit API keys)
- Runs `npm install` in the `dagger/` directory to install pipeline dependencies
- Calls `just runtime` to verify the container runtime is available and report which one is active

## Test plan

- [ ] Run `just bootstrap` on a fresh clone and verify `compose/.env` is created
- [ ] Confirm `dagger/node_modules` is populated after bootstrap
- [ ] Confirm the container runtime line is printed at the end
- [ ] Run `just bootstrap` a second time and verify it does not overwrite an existing `compose/.env`
- [ ] Run `just --list` and confirm `bootstrap` appears in the recipe list

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)