### PR TITLE
docs: add CHANGELOG.md and link contributing docs in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,91 @@
+# Changelog
+
+All notable changes to AchaeanFleet are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
+No version tags exist yet; sections are anchored to commit SHAs and dates.
+
+---
+
+## [2026-04-05] — `20b70bc`
+
+### Added
+
+- GitHub CLI (`gh`) pre-installed in the base node image for CI/CD workflows
+
+---
+
+## [2026-04-03] — `309f75e`
+
+### Added
+
+- `CONTRIBUTING.md` with Dockerfile conventions, PR process, and branch strategy
+- `SECURITY.md` with responsible disclosure process
+- `CODE_OF_CONDUCT.md` (Contributor Covenant)
+- `LICENSE` (MIT)
+
+---
+
+## [2026-03-31] — `a04f395`, `8b5212b`
+
+### Fixed
+
+- CI: use `docker` driver for buildx so daemon images are shared across build steps
+- CI: load base images from build artifacts before vessel builds so `FROM` references resolve
+
+---
+
+## [2026-03-28] — `23bc589`
+
+### Changed
+
+- **Breaking:** Migrated mesh namespace from `aimaestro-mesh` → `homeric-mesh` (ADR-006)
+- **Breaking:** Renamed environment variable `AIM_HOST` → `AGAMEMNON_URL`
+- Replaced `agent-server.js` shim with the new Agamemnon agent sidecar entrypoint
+
+---
+
+## [2026-03-27] — `3ff5967`
+
+### Added
+
+- Enabled `hephaestus@ProjectHephaestus` plugin for CI tooling integration
+
+---
+
+## [2026-03-23] — `1da1354`
+
+### Changed
+
+- CI runners switched from self-hosted to `ubuntu-latest` for improved reliability
+
+---
+
+## [2026-03-15] — `5794587`, `d72575c`, `d584b71`
+
+### Added
+
+- Podman support: auto-detect container runtime (Docker vs Podman) in scripts
+- Pod YAML specs in `pods/` for rootless Podman deployments
+- `push-and-notify` recipe in `justfile`
+
+### Fixed
+
+- `bases/Dockerfile.node`: renamed `node` user to `agent` for Podman rootless compatibility
+- Simplified runtime version display in build output
+
+---
+
+## [2026-03-15] — `5d6377a`
+
+### Added
+
+- Repository scaffold: `justfile`, `pixi.toml`, `build-all.sh`, initial `README.md`
+
+---
+
+## [2026-03-14] — `5bbac20`
+
+### Added
+
+- Initial commit: base Dockerfiles (`node`, `python`, `minimal`), vessel Dockerfiles for all
+  supported agent types, Docker Compose files, and Dagger CI pipeline scaffold

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ Configure its path via `AGAMEMNON_URL` in `compose/.env`.
 4. Add to the build matrix in `.github/workflows/ci.yml`
 5. Run `just build-vessel <name>` to verify
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for Dockerfile conventions, branch strategy, and the PR
+review process. Changes are documented in [CHANGELOG.md](CHANGELOG.md).
+
 ## Nomad (Phase 6)
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `CHANGELOG.md` at the repository root using [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format, documenting all 12 commits grouped into logical milestone sections anchored by commit SHA and date (no version tags exist yet)
- Adds a **Contributing** section to `README.md` pointing readers to `CONTRIBUTING.md` and `CHANGELOG.md`
- `CONTRIBUTING.md` already existed (added in `309f75e`), so no changes needed there

## Test plan

- [ ] Verify `CHANGELOG.md` renders correctly on GitHub
- [ ] Verify `README.md` Contributing section links resolve to existing files
- [ ] Confirm all commit entries in CHANGELOG match `git log --oneline`

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)