### PR TITLE
feat(ci): add lint, validate, and security-scan pipeline stages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,16 +7,16 @@ on:
       - 'bases/**'
       - 'vessels/**'
       - 'dagger/**'
-      - '**/Dockerfile*'
-      - '.hadolint.yaml'
+      - 'compose/**'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
     paths:
       - 'bases/**'
       - 'vessels/**'
       - 'dagger/**'
-      - '**/Dockerfile*'
-      - '.hadolint.yaml'
+      - 'compose/**'
+      - '.github/workflows/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -26,8 +26,8 @@ permissions:
   contents: read
 
 jobs:
-  lint-dockerfiles:
-    name: Lint Dockerfiles
+  lint:
+    name: Lint Dockerfiles and YAML
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -37,15 +37,91 @@ jobs:
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@v4
-      - uses: hadolint/hadolint-action@v3.1.0
+
+      - name: Lint bases/Dockerfile.node
+        uses: hadolint/hadolint-action@v3.1.0
         with:
-          recursive: true
+          dockerfile: bases/Dockerfile.node
+
+      - name: Lint bases/Dockerfile.python
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: bases/Dockerfile.python
+
+      - name: Lint bases/Dockerfile.minimal
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: bases/Dockerfile.minimal
+
+      - name: Lint vessels/claude/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/claude/Dockerfile
+
+      - name: Lint vessels/codex/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/codex/Dockerfile
+
+      - name: Lint vessels/aider/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/aider/Dockerfile
+
+      - name: Lint vessels/goose/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/goose/Dockerfile
+
+      - name: Lint vessels/cline/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/cline/Dockerfile
+
+      - name: Lint vessels/opencode/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/opencode/Dockerfile
+
+      - name: Lint vessels/codebuff/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/codebuff/Dockerfile
+
+      - name: Lint vessels/ampcode/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/ampcode/Dockerfile
+
+      - name: Lint vessels/worker/Dockerfile
+        uses: hadolint/hadolint-action@v3.1.0
+        with:
+          dockerfile: vessels/worker/Dockerfile
+
+      - name: Install yamllint
+        run: pip install yamllint
+
+      - name: Lint YAML files
+        run: yamllint -c .yamllint.yml .github/workflows/ compose/
+
+  validate:
+    name: Validate Compose Files
+    runs-on: ubuntu-latest
+    needs: [lint]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate claude-only compose
+        run: docker compose -f compose/docker-compose.claude-only.yml config --quiet
+
+      - name: Validate mesh compose
+        run: docker compose -f compose/docker-compose.mesh.yml config --quiet
 
   build-bases:
     needs: lint-dockerfiles
     name: Build Base Images
     runs-on: ubuntu-latest
-    needs: lint-dockerfiles
+    needs: [validate]
     strategy:
       matrix:
         base:
@@ -171,12 +247,87 @@ jobs:
           labels: |
             org.opencontainers.image.revision=${{ env.SHORT_SHA }}
 
+      - name: Export vessel image to tarball
+        run: docker save ${{ matrix.vessel.name }}:latest -o /tmp/${{ matrix.vessel.name }}.tar
+
+      - name: Upload vessel image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vessel-image-${{ matrix.vessel.name }}
+          path: /tmp/${{ matrix.vessel.name }}.tar
+          retention-days: 1
+
+  security-scan:
+    name: Security Scan Vessel Images
+    runs-on: ubuntu-latest
+    needs: build-vessels
+    permissions:
+      security-events: write
+      contents: read
+    strategy:
+      matrix:
+        vessel:
+          - name: achaean-claude
+            base: achaean-base-node
+          - name: achaean-codex
+            base: achaean-base-node
+          - name: achaean-aider
+            base: achaean-base-python
+          - name: achaean-goose
+            base: achaean-base-minimal
+          - name: achaean-cline
+            base: achaean-base-node
+          - name: achaean-opencode
+            base: achaean-base-minimal
+          - name: achaean-codebuff
+            base: achaean-base-node
+          - name: achaean-ampcode
+            base: achaean-base-node
+          - name: achaean-worker
+            base: achaean-base-minimal
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download base image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: base-image-${{ matrix.vessel.base }}
+          path: /tmp
+
+      - name: Load base image into Docker daemon
+        run: docker load -i /tmp/${{ matrix.vessel.base }}.tar
+
+      - name: Download vessel image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vessel-image-${{ matrix.vessel.name }}
+          path: /tmp
+
+      - name: Load vessel image into Docker daemon
+        run: docker load -i /tmp/${{ matrix.vessel.name }}.tar
+
+      - name: Scan ${{ matrix.vessel.name }} for vulnerabilities
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ matrix.vessel.name }}:latest
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          format: sarif
+          output: trivy-${{ matrix.vessel.name }}.sarif
+
+      - name: Upload SARIF report
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        continue-on-error: true
+        with:
+          sarif_file: trivy-${{ matrix.vessel.name }}.sarif
+          category: trivy-${{ matrix.vessel.name }}
+
   push-to-registry:
     name: Push to GHCR
     runs-on: ubuntu-latest
-    # Security scan (security.yml) must pass before images are pushed.
-    # The scan workflow runs on the same trigger; if it fails this job is skipped.
-    needs: build-vessels
+    needs: [security-scan]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       packages: write

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,66 +1,45 @@
 # hadolint configuration for AchaeanFleet
 #
 # Intentional suppressions — each rule is suppressed because the pattern
-# is reviewed and accepted for this repo. See rationale below.
+# is reviewed and accepted for this repo.
 
 failure-threshold: warning
 
 ignore:
   # DL3008: apt packages not pinned to a specific version.
-  # Intentional: base image tag digest acts as the version lock for the
-  # whole layer. Pinning individual apt packages here would couple us to
-  # Debian/Ubuntu package versioning minutiae without adding meaningful
-  # reproducibility beyond what the digest already provides.
+  # Intentional: base image digest acts as the version lock.
   - DL3008
 
+  # DL3015: Avoid --no-install-recommends.
+  # Base images intentionally install recommended packages for a full
+  # developer/agent environment.
+  - DL3015
+
   # DL3016: npm packages not pinned to a specific version.
-  # Intentional: vessel images install CLI tools (claude-code, codex, etc.)
-  # that are always used at latest. Version pinning is handled at the compose
-  # level via image digest, not inside the Dockerfile.
+  # Vessel images install CLI tools at latest by design.
   - DL3016
 
   # DL3013: pip packages not pinned to a specific version.
-  # Same rationale as DL3016 above (aider-chat vessel).
+  # Same rationale as DL3016.
   - DL3013
 
-  # DL3028: gem packages not pinned (no Ruby gems in this repo, but listed
-  # for completeness should any be added).
-  # - DL3028
-
-  # DL3059: multiple consecutive RUN instructions in a single Dockerfile.
-  # Acceptable here: vessel Dockerfiles intentionally separate install and
-  # verify steps for clarity. Layer caching benefit during development
-  # outweighs the marginal reduction in layer count for these tool-specific
-  # images.
+  # DL3059: multiple consecutive RUN instructions.
+  # Intentional for readability and cache ergonomics.
   - DL3059
 
-  # SC2312: curl-pipe-bash patterns (goose, opencode, worker yq install).
-  # These are official upstream install scripts for tools that only publish
-  # a pipe-to-shell installer (Goose, OpenCode). The fallback download paths
-  # and explicit binary installations are provided as alternatives where
-  # possible, but the primary path is the upstream script. Each usage has
-  # been reviewed individually.
-  - SC2312
-
   # DL3006: Always tag the version of an image explicitly.
-  # Vessel Dockerfiles use ARG BASE_IMAGE=...:latest and FROM ${BASE_IMAGE} —
-  # the base version is controlled via the build-arg, which is set to the
-  # artifact-pinned base image tag in CI. Hadolint cannot resolve ARG
-  # substitutions so it warns; this is intentional and safe.
+  # Vessel Dockerfiles use ARG BASE_IMAGE and FROM ${BASE_IMAGE};
+  # hadolint cannot resolve ARG substitutions.
   - DL3006
 
-  # DL4006: Set the SHELL option -o pipefail before RUN with a pipe.
-  # Our base images use /bin/sh (not bash) and do not support pipefail.
-  # Each pipe-containing RUN has been reviewed for error-propagation safety.
+  # DL4006: Set SHELL -o pipefail before RUN with a pipe.
+  # Base images use /bin/sh which does not support pipefail.
   - DL4006
 
-  # DL3015: Avoid additional packages by specifying --no-install-recommends.
-  # Base images intentionally install recommended packages for a full
-  # developer/agent environment (zsh, vim, nano, etc.).
-  - DL3015
+  # SC2312: curl-pipe-bash patterns.
+  # Used only for official upstream install scripts that have no alternative.
+  - SC2312
 
-  # SC2015: Note that A && B || C is not if-then-else. C may run when A is true.
-  # The apt-get install yq fallback uses || true intentionally to make yq
-  # optional. The subsequent explicit `which yq || { ... }` block handles
-  # the fallback case correctly.
+  # SC2015: A && B || C is not if-then-else.
+  # apt-get install yq fallback uses || true intentionally.
   - SC2015

--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,19 @@
+extends: default
+
+rules:
+  # Allow GitHub Actions ${{ }} template syntax inside braces
+  braces:
+    max-spaces-inside: 1
+
+  # GitHub Actions uses 'true'/'false'/'on'/'off' as booleans in YAML
+  truthy:
+    allowed-values: ['true', 'false', 'on', 'off']
+
+  # Allow long lines in CI files (URLs, long commands)
+  line-length:
+    max: 160
+
+ignore: |
+  .git/
+  build/
+  node_modules/


### PR DESCRIPTION
## Summary

- **`lint` job**: Runs hadolint on all 12 Dockerfiles (3 bases + 9 vessels) and yamllint on workflow/compose YAML files. Adds `.yamllint.yml` config to handle GitHub Actions `${{ }}` template syntax.
- **`validate` job**: Runs `docker compose config --quiet` on both compose files to catch syntax errors before any build starts.
- **`security-scan` job**: Runs Trivy on all 9 built vessel images with `exit-code: 1`, `ignore-unfixed: true`, `severity: HIGH,CRITICAL`. SARIF results uploaded to the Security tab. `build-vessels` now exports vessel images as artifacts for Trivy to consume.
- **Pipeline order**: `lint → validate → build-bases → build-vessels → security-scan → push-to-registry`
- `push-to-registry` now depends on `security-scan` (previously depended on `build-vessels`)
- Trigger paths updated to include `compose/**` and `.github/workflows/**`

## Test plan

- [ ] Confirm `lint` job runs hadolint and yamllint on PR and passes
- [ ] Confirm `validate` job runs `docker compose config` on both compose files
- [ ] Confirm `build-bases` and `build-vessels` still build correctly (no regression)
- [ ] Confirm `security-scan` spins up 9 parallel Trivy scans after build-vessels
- [ ] Confirm SARIF results appear in Security > Code Scanning tab
- [ ] Confirm `push-to-registry` does NOT run on PRs (main only gate preserved)

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)