### PR TITLE
feat: add .editorconfig for consistent formatting across editors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,48 @@
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+
+[*.{yml,yaml}]
+indent_style = space
+indent_size = 2
+
+[*.{json,jsonc}]
+indent_style = space
+indent_size = 2
+
+[*.{ts,js}]
+indent_style = space
+indent_size = 2
+
+[*.hcl]
+indent_style = space
+indent_size = 2
+
+[*.toml]
+indent_style = space
+indent_size = 2
+
+[Dockerfile*]
+indent_style = space
+indent_size = 4
+
+[*.sh]
+indent_style = space
+indent_size = 4
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[justfile]
+indent_style = tab
+
+[Makefile]
+indent_style = tab
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
## Summary

- Adds `.editorconfig` to the repo root with rules covering all file types in the project
- `indent_size=2` for YAML, JSON, TypeScript/JS, HCL, TOML
- `indent_size=4` for Dockerfiles, shell scripts, Python
- Tab indentation for `justfile` and `Makefile` (syntax requirement)
- LF line endings, final newline, and trailing whitespace trimming as defaults
- Markdown files exempt from trailing whitespace trimming (intentional line breaks)

## Test plan

- [ ] Verify `.editorconfig` is present in repo root
- [ ] Open a Dockerfile in VS Code — confirm 4-space indent is detected
- [ ] Open a YAML file in VS Code — confirm 2-space indent is detected
- [ ] Open a `.sh` script — confirm 4-space indent is detected
- [ ] Confirm JetBrains and vim also auto-detect (EditorConfig plugins required)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)