### PR TITLE
feat(lint): add pre-commit hooks for Dockerfile, YAML, and shell linting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,83 @@
+---
+# AchaeanFleet pre-commit configuration
+# Install: pre-commit install  (or: just lint-install)
+# Run manually: pre-commit run --all-files  (or: just lint)
+# Update hook revisions: pre-commit autoupdate
+
+repos:
+  # ---------------------------------------------------------------------------
+  # Standard file hygiene
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: [--unsafe]  # allow YAML anchors (used in Docker Compose)
+      - id: check-merge-conflict
+      - id: check-added-large-files
+        args: [--maxkb=500]
+
+  # ---------------------------------------------------------------------------
+  # YAML linting (with project-specific overrides in .yamllint.yaml)
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.35.1
+    hooks:
+      - id: yamllint
+        args: [--config-file, .yamllint.yaml]
+
+  # ---------------------------------------------------------------------------
+  # Dockerfile linting (hadolint)
+  # Waived rules (intentional patterns in this repo):
+  #   DL3008: apt-get without --no-install-recommends — base images include dev tools intentionally
+  #   DL3015: same as DL3008
+  #   DL3013: pip without version pin — agent tool versions track latest by design
+  #   DL3016: npm without version pin — same as DL3013
+  #   DL3042: pip cache dir — handled by --no-cache-dir in vessel Dockerfiles
+  #   DL3046: useradd without -l — UID 1000 is standard, image size impact is acceptable
+  #   DL3059: Multiple consecutive RUN — intentional grouping in base images
+  #   DL4006: SHELL pipefail — piped RUN commands in base/vessel images are intentional
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/hadolint/hadolint
+    rev: v2.12.0
+    hooks:
+      - id: hadolint
+        args:
+          - --ignore=DL3008
+          - --ignore=DL3013
+          - --ignore=DL3015
+          - --ignore=DL3016
+          - --ignore=DL3042
+          - --ignore=DL3046
+          - --ignore=DL3059
+          - --ignore=DL4006
+
+  # ---------------------------------------------------------------------------
+  # Shell script linting (shellcheck)
+  # ---------------------------------------------------------------------------
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.10.0.1
+    hooks:
+      - id: shellcheck
+        args: [--severity=warning]
+
+  # ---------------------------------------------------------------------------
+  # Local hooks
+  # ---------------------------------------------------------------------------
+  - repo: local
+    hooks:
+      # Catch curl-pipe-bash patterns in Dockerfiles before hadolint runs.
+      # Existing intentional uses:
+      #   bases/Dockerfile.python, bases/Dockerfile.minimal — nodesource setup
+      #   bases/Dockerfile.node, bases/Dockerfile.python, bases/Dockerfile.minimal — Oh My Zsh install
+      #   vessels/goose, vessels/opencode — official binary install scripts
+      # If you add a new curl-pipe-bash, document why with a comment above it.
+      - id: no-new-curl-pipe-bash
+        name: Warn on new curl-pipe-bash patterns
+        language: pygrep
+        entry: 'curl.*\|\s*(bash|sh)'
+        files: 'Dockerfile'
+        types: [file]
+        exclude: 'bases/Dockerfile\.(node|python|minimal)|vessels/(goose|opencode)/Dockerfile'

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,13 @@
+---
+extends: default
+rules:
+  line-length:
+    max: 120
+  truthy:
+    # GitHub Actions uses 'on:' as a mapping key; Docker Compose uses true/false
+    allowed-values: ['true', 'false', 'on', 'off']
+  indentation:
+    # Docker Compose and Kubernetes YAML use mixed sequence indentation styles
+    indent-sequences: whatever
+  braces:
+    max-spaces-inside: 1

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,6 +54,22 @@ just build-bases
 just verify
 ```
 
+### Linting
+
+This project uses [pre-commit](https://pre-commit.com/) for local linting.
+Hooks cover Dockerfile linting (hadolint), YAML validation (yamllint),
+shell script analysis (shellcheck), and standard file hygiene.
+
+```bash
+# Install hooks (run once after cloning)
+just lint-install
+
+# Run all linters manually across all files
+just lint
+```
+
+Hooks run automatically on `git commit` after installation.
+
 ## What You Can Contribute
 
 - **Vessel Dockerfiles** — New agent-specific container images

--- a/justfile
+++ b/justfile
@@ -154,6 +154,18 @@ mesh-down:
     {{compose_cmd}} -f compose/docker-compose.mesh.yml down
 
 # =============================================================================
+# Lint
+# =============================================================================
+
+# Install pre-commit hooks into .git/hooks (run once after cloning)
+lint-install:
+    pre-commit install
+
+# Run all linters across all files
+lint:
+    pre-commit run --all-files
+
+# =============================================================================
 # Cleanup
 # =============================================================================
 


### PR DESCRIPTION
## Summary

- Add `.pre-commit-config.yaml` with hadolint, yamllint, shellcheck, standard file hygiene hooks, and a local pygrep hook to catch new curl-pipe-bash patterns in Dockerfiles
- Add `.yamllint.yaml` with overrides for GitHub Actions (`on:` truthy key) and Docker Compose (YAML anchors, mixed indentation)
- Add `just lint` and `just lint-install` recipes to `justfile`
- Document linting setup in `CONTRIBUTING.md` under _Development Setup > Linting_

## Test plan

- [x] `pre-commit run --all-files` exits 0 (all hooks pass)
- [x] `just lint` invokes `pre-commit run --all-files`
- [x] `just lint-install` installs hooks to `.git/hooks/pre-commit`
- [x] hadolint waivers documented for intentional patterns (npm/pip unpinned versions, apt without `--no-install-recommends`, curl-pipe-bash in base/vessel images)
- [x] curl-pipe-bash pygrep hook excludes known-intentional Dockerfiles; new ones will be caught

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)