### PR TITLE
feat(compose): add resource limits to all compose services

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -85,3 +85,63 @@ AMPCODE_PROJECT=/home/mvillmow/Projects
 # Network
 # =============================================================================
 MESH_NETWORK=homeric-mesh
+
+# =============================================================================
+# Resource Limits
+# Prevent any single agent from OOM-killing the host or starving other containers.
+# Tune these based on your host's available memory and CPU.
+# =============================================================================
+
+# Claude agents (aindrea, baird, vegai) — heavier LLM workloads
+CLAUDE_MEM_LIMIT=4G
+CLAUDE_MEM_RESERVATION=512M
+CLAUDE_CPU_LIMIT=2.0
+CLAUDE_CPU_RESERVATION=0.25
+
+# Codex agent
+CODEX_MEM_LIMIT=4G
+CODEX_MEM_RESERVATION=512M
+CODEX_CPU_LIMIT=2.0
+CODEX_CPU_RESERVATION=0.25
+
+# Aider agent
+AIDER_MEM_LIMIT=4G
+AIDER_MEM_RESERVATION=512M
+AIDER_CPU_LIMIT=2.0
+AIDER_CPU_RESERVATION=0.25
+
+# Goose agent
+GOOSE_MEM_LIMIT=4G
+GOOSE_MEM_RESERVATION=512M
+GOOSE_CPU_LIMIT=2.0
+GOOSE_CPU_RESERVATION=0.25
+
+# Cline agent
+CLINE_MEM_LIMIT=4G
+CLINE_MEM_RESERVATION=512M
+CLINE_CPU_LIMIT=2.0
+CLINE_CPU_RESERVATION=0.25
+
+# OpenCode agent
+OPENCODE_MEM_LIMIT=4G
+OPENCODE_MEM_RESERVATION=512M
+OPENCODE_CPU_LIMIT=2.0
+OPENCODE_CPU_RESERVATION=0.25
+
+# Codebuff agent
+CODEBUFF_MEM_LIMIT=4G
+CODEBUFF_MEM_RESERVATION=512M
+CODEBUFF_CPU_LIMIT=2.0
+CODEBUFF_CPU_RESERVATION=0.25
+
+# AmpCode agent
+AMPCODE_MEM_LIMIT=4G
+AMPCODE_MEM_RESERVATION=512M
+AMPCODE_CPU_LIMIT=2.0
+AMPCODE_CPU_RESERVATION=0.25
+
+# Shell Worker — lighter workload, no AI model
+WORKER_MEM_LIMIT=1G
+WORKER_MEM_RESERVATION=128M
+WORKER_CPU_LIMIT=1.0
+WORKER_CPU_RESERVATION=0.1

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -49,6 +49,79 @@ x-security: &security
   cap_drop: [ALL]
   security_opt: [no-new-privileges:true]
 
+# Resource limits for Claude/Codex/Aider/Goose/Cline/OpenCode/Codebuff/AmpCode agents
+x-resources-claude: &resources-claude
+  limits:
+    memory: ${CLAUDE_MEM_LIMIT:-4G}
+    cpus: '${CLAUDE_CPU_LIMIT:-2.0}'
+  reservations:
+    memory: ${CLAUDE_MEM_RESERVATION:-512M}
+    cpus: '${CLAUDE_CPU_RESERVATION:-0.25}'
+
+x-resources-codex: &resources-codex
+  limits:
+    memory: ${CODEX_MEM_LIMIT:-4G}
+    cpus: '${CODEX_CPU_LIMIT:-2.0}'
+  reservations:
+    memory: ${CODEX_MEM_RESERVATION:-512M}
+    cpus: '${CODEX_CPU_RESERVATION:-0.25}'
+
+x-resources-aider: &resources-aider
+  limits:
+    memory: ${AIDER_MEM_LIMIT:-4G}
+    cpus: '${AIDER_CPU_LIMIT:-2.0}'
+  reservations:
+    memory: ${AIDER_MEM_RESERVATION:-512M}
+    cpus: '${AIDER_CPU_RESERVATION:-0.25}'
+
+x-resources-goose: &resources-goose
+  limits:
+    memory: ${GOOSE_MEM_LIMIT:-4G}
+    cpus: '${GOOSE_CPU_LIMIT:-2.0}'
+  reservations:
+    memory: ${GOOSE_MEM_RESERVATION:-512M}
+    cpus: '${GOOSE_CPU_RESERVATION:-0.25}'
+
+x-resources-cline: &resources-cline
+  limits:
+    memory: ${CLINE_MEM_LIMIT:-4G}
+    cpus: '${CLINE_CPU_LIMIT:-2.0}'
+  reservations:
+    memory: ${CLINE_MEM_RESERVATION:-512M}
+    cpus: '${CLINE_CPU_RESERVATION:-0.25}'
+
+x-resources-opencode: &resources-opencode
+  limits:
+    memory: ${OPENCODE_MEM_LIMIT:-4G}
+    cpus: '${OPENCODE_CPU_LIMIT:-2.0}'
+  reservations:
+    memory: ${OPENCODE_MEM_RESERVATION:-512M}
+    cpus: '${OPENCODE_CPU_RESERVATION:-0.25}'
+
+x-resources-codebuff: &resources-codebuff
+  limits:
+    memory: ${CODEBUFF_MEM_LIMIT:-4G}
+    cpus: '${CODEBUFF_CPU_LIMIT:-2.0}'
+  reservations:
+    memory: ${CODEBUFF_MEM_RESERVATION:-512M}
+    cpus: '${CODEBUFF_CPU_RESERVATION:-0.25}'
+
+x-resources-ampcode: &resources-ampcode
+  limits:
+    memory: ${AMPCODE_MEM_LIMIT:-4G}
+    cpus: '${AMPCODE_CPU_LIMIT:-2.0}'
+  reservations:
+    memory: ${AMPCODE_MEM_RESERVATION:-512M}
+    cpus: '${AMPCODE_CPU_RESERVATION:-0.25}'
+
+x-resources-worker: &resources-worker
+  limits:
+    memory: ${WORKER_MEM_LIMIT:-1G}
+    cpus: '${WORKER_CPU_LIMIT:-1.0}'
+  reservations:
+    memory: ${WORKER_MEM_RESERVATION:-128M}
+    cpus: '${WORKER_CPU_RESERVATION:-0.1}'
+
 services:
   # -------------------------------------------------------------------------
   # Claude agents (Node base)

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -70,6 +70,8 @@ services:
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-claude
     healthcheck: *healthcheck
     <<: *security
 
@@ -90,6 +92,8 @@ services:
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-claude
     healthcheck: *healthcheck
     <<: *security
 
@@ -112,6 +116,8 @@ services:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Codex-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-codex
     healthcheck: *healthcheck
     <<: *security
 
@@ -135,6 +141,8 @@ services:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Aider-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-aider
     healthcheck: *healthcheck
     <<: *security
 
@@ -157,6 +165,8 @@ services:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Goose-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-goose
     healthcheck: *healthcheck
     <<: *security
 
@@ -179,6 +189,8 @@ services:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Cline-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-cline
     healthcheck: *healthcheck
     <<: *security
 
@@ -201,6 +213,8 @@ services:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Opencode-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-opencode
     healthcheck: *healthcheck
     <<: *security
 
@@ -223,6 +237,8 @@ services:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Codebuff-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-codebuff
     healthcheck: *healthcheck
     <<: *security
 
@@ -245,6 +261,8 @@ services:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Ampcode-1:/workspace
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-ampcode
     healthcheck: *healthcheck
     <<: *security
 
@@ -267,5 +285,7 @@ services:
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
     restart: unless-stopped
+    deploy:
+      resources: *resources-worker
     healthcheck: *healthcheck
     <<: *security


### PR DESCRIPTION
## Summary

- Added `deploy.resources.limits` and `deploy.resources.reservations` to every service in `docker-compose.claude-only.yml` (3 services) and `docker-compose.mesh.yml` (10 services)
- Limits are configurable via `.env` variables (e.g. `CLAUDE_MEM_LIMIT`, `WORKER_MEM_LIMIT`)
- Updated `compose/.env.example` with all new variables and their defaults
- Added resource tuning documentation to `README.md`

**Defaults:**
- AI agents (Claude, Codex, Aider, Goose, Cline, OpenCode, Codebuff, AmpCode): `memory: 4G`, `cpus: 2.0`, reservation `512M / 0.25`
- Shell Worker: `memory: 1G`, `cpus: 1.0`, reservation `128M / 0.1`

`docker-compose.mesh.yml` uses YAML anchors (`x-resources-*`) to keep each agent's limits DRY and independently tunable.

## Test plan

- [x] Both compose files parse as valid YAML (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] All 10 mesh services and 3 claude-only services confirmed to have `deploy:` blocks via `grep`
- [x] `compose/.env.example` documents all new variables with sensible defaults
- [ ] `docker compose config` shows resource limits for every service (requires Docker 20.10+ with Compose V2 plugin)

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)