### PR TITLE
fix(bases): install sudo in python and minimal base Dockerfiles

### DIFF
--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     build-essential \
     python3 \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20.x

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     procps \
     ca-certificates \
     build-essential \
+    sudo \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js 20.x


### PR DESCRIPTION
## Summary

- Added `sudo` to the `apt-get install` list in `bases/Dockerfile.python`
- Added `sudo` to the `apt-get install` list in `bases/Dockerfile.minimal`

Both Dockerfiles wrote `agent ALL=(ALL) NOPASSWD:ALL` to `/etc/sudoers` without having `sudo` installed, meaning the entry was silently ineffective (or the sudoers file itself might not exist on the base image). This matches the existing `Dockerfile.node` pattern which already installs `sudo` explicitly.

## Test plan

- [ ] Build `achaean-base-python` and verify `sudo` binary is present and the agent user can run `sudo` commands
- [ ] Build `achaean-base-minimal` and verify `sudo` binary is present and the agent user can run `sudo` commands
- [ ] Verify CI matrix builds pass for both bases

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)