### PR TITLE
feat(justfile): add clean-dangling and clean-all recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -167,3 +167,23 @@ clean:
         | grep '^achaean-' \
         | xargs -r ${container_cmd} rmi || true
     echo "=== Cleaned ==="
+
+# Prune dangling images, stopped containers, and build cache
+clean-dangling:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    container_cmd="$(which podman 2>/dev/null || echo docker)"
+    echo "=== Pruning dangling images (${container_cmd}) ==="
+    ${container_cmd} image prune -f
+    echo "=== Pruning stopped containers ==="
+    ${container_cmd} container prune -f
+    echo "=== Pruning build cache ==="
+    ${container_cmd} builder prune -f || true
+    echo "=== Dangling artifacts removed ==="
+
+# Full cleanup: remove achaean-* images + dangling layers + build cache
+clean-all:
+    @echo "=== Full cleanup ==="
+    just clean
+    just clean-dangling
+    @echo "=== All cleaned ==="


### PR DESCRIPTION
## Summary

- Add `just clean-dangling` recipe: prunes dangling images (`image prune -f`), stopped containers (`container prune -f`), and build cache (`builder prune -f`)
- Add `just clean-all` recipe: one-command full cleanup combining `just clean` + `just clean-dangling`
- Both recipes auto-detect container runtime (podman/docker) consistent with existing patterns

## Motivation

Building 3 base images and 9 vessel images generates many intermediate layers and dangling images. The existing `just clean` only removes final `achaean-*` tagged images, leaving potentially gigabytes of dangling layers. This is particularly impactful on WSL2 systems with limited virtual disk space.

## Test plan

- [ ] `just clean-dangling` runs without error on a system with podman or docker
- [ ] `just clean-all` chains `clean` → `clean-dangling` correctly
- [ ] `just --list` shows help text for both new recipes
- [ ] `builder prune` failure is non-fatal (`|| true`) for runtimes that don't support it (e.g. podman rootless)

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)