### PR TITLE
feat(ci): add Dependabot config for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,124 @@
+version: 2
+updates:
+  # GitHub Actions — update action versions in workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  # Docker base images — bases/ and vessels/
+  - package-ecosystem: "docker"
+    directory: "/bases"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      base-images:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/aider"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/ampcode"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/claude"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/cline"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/codebuff"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/codex"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/goose"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/opencode"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  - package-ecosystem: "docker"
+    directory: "/vessels/worker"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    labels:
+      - "dependencies"
+      - "docker"
+
+  # npm — dagger/package.json
+  - package-ecosystem: "npm"
+    directory: "/dagger"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      dagger-deps:
+        patterns:
+          - "*"
+    labels:
+      - "dependencies"
+      - "npm"


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with weekly automated dependency update PRs for:
  - **github-actions**: all GitHub Actions used in `.github/workflows/ci.yml`
  - **docker**: base images in `bases/` and each vessel Dockerfile in `vessels/`
  - **npm**: `@dagger.io/dagger` and dev deps in `dagger/package.json`
- All updates scheduled weekly on Mondays
- PRs are labelled `dependencies` + ecosystem (`github-actions`, `docker`, or `npm`) for easy filtering

Note: `pip` ecosystem is omitted because `aider-chat` is installed inline in a Dockerfile with no standalone `requirements.txt` or `pyproject.toml`; Dependabot's docker ecosystem will still flag `FROM python:...` base image updates for the aider vessel.

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid YAML (no syntax errors)
- [ ] Verify Dependabot is enabled in repo Settings → Code security → Dependabot
- [ ] Check that Dependabot creates PRs within a week of merge

Closes #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)