### PR TITLE
feat(security): add no-new-privileges and cap_drop: ALL to all compose services

### DIFF
--- a/compose/docker-compose.claude-only.yml
+++ b/compose/docker-compose.claude-only.yml
@@ -15,6 +15,13 @@
 
 version: "3.9"
 
+# Shared security hardening applied to all services
+x-security: &security
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+
 networks:
   homeric-mesh:
     name: ${MESH_NETWORK:-homeric-mesh}
@@ -37,6 +44,7 @@ services:
   # Claude agent: Aindrea (odyssey-mainline-analysis)
   # -------------------------------------------------------------------------
   hi-aindrea:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-aindrea
     hostname: hi-aindrea
@@ -69,6 +77,7 @@ services:
   # Claude agent: Baird (scylla-repo-monitor)
   # -------------------------------------------------------------------------
   hi-baird:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-baird
     hostname: hi-baird
@@ -101,6 +110,7 @@ services:
   # Claude agent: VegAI (villmow-general-agent)
   # -------------------------------------------------------------------------
   hi-vegai:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-vegai
     hostname: hi-vegai

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -51,11 +51,6 @@ x-healthcheck: &healthcheck
   start_period: 15s
   retries: 3
 
-# Shared security hardening (least-privilege defaults)
-x-security: &security
-  cap_drop: [ALL]
-  security_opt: [no-new-privileges:true]
-
 # Resource limits for Claude/Codex/Aider/Goose/Cline/OpenCode/Codebuff/AmpCode agents
 x-resources-claude: &resources-claude
   limits:

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -25,6 +25,13 @@ networks:
     name: ${MESH_NETWORK:-homeric-mesh}
     driver: bridge
 
+# Shared security hardening applied to all services
+x-security: &security
+  security_opt:
+    - no-new-privileges:true
+  cap_drop:
+    - ALL
+
 # Shared environment for all agents
 x-common-env: &common-env
   AGAMEMNON_URL: ${AGAMEMNON_URL:-https://caddy:8443}
@@ -127,6 +134,7 @@ services:
   # Claude agents (Node base)
   # -------------------------------------------------------------------------
   hi-aindrea:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-aindrea
     hostname: hi-aindrea
@@ -149,6 +157,7 @@ services:
     <<: *security
 
   hi-baird:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-baird
     hostname: hi-baird
@@ -174,6 +183,7 @@ services:
   # Codex agent (Node base)
   # -------------------------------------------------------------------------
   hi-codex-1:
+    <<: *security
     image: ${CODEX_IMAGE:-achaean-codex:latest}
     container_name: hi-codex-1
     hostname: hi-codex-1
@@ -198,6 +208,7 @@ services:
   # Aider agent (Python base)
   # -------------------------------------------------------------------------
   hi-aider-1:
+    <<: *security
     image: ${AIDER_IMAGE:-achaean-aider:latest}
     container_name: hi-aider-1
     hostname: hi-aider-1
@@ -223,6 +234,7 @@ services:
   # Goose agent (minimal/binary base)
   # -------------------------------------------------------------------------
   hi-goose-1:
+    <<: *security
     image: ${GOOSE_IMAGE:-achaean-goose:latest}
     container_name: hi-goose-1
     hostname: hi-goose-1
@@ -247,6 +259,7 @@ services:
   # Cline agent (Node base)
   # -------------------------------------------------------------------------
   hi-cline-1:
+    <<: *security
     image: ${CLINE_IMAGE:-achaean-cline:latest}
     container_name: hi-cline-1
     hostname: hi-cline-1
@@ -271,6 +284,7 @@ services:
   # OpenCode agent (minimal/binary base)
   # -------------------------------------------------------------------------
   hi-opencode-1:
+    <<: *security
     image: ${OPENCODE_IMAGE:-achaean-opencode:latest}
     container_name: hi-opencode-1
     hostname: hi-opencode-1
@@ -295,6 +309,7 @@ services:
   # Codebuff agent (Node base)
   # -------------------------------------------------------------------------
   hi-codebuff-1:
+    <<: *security
     image: ${CODEBUFF_IMAGE:-achaean-codebuff:latest}
     container_name: hi-codebuff-1
     hostname: hi-codebuff-1
@@ -319,6 +334,7 @@ services:
   # AmpCode agent (Node base)
   # -------------------------------------------------------------------------
   hi-ampcode-1:
+    <<: *security
     image: ${AMPCODE_IMAGE:-achaean-ampcode:latest}
     container_name: hi-ampcode-1
     hostname: hi-ampcode-1
@@ -343,6 +359,7 @@ services:
   # Shell Worker (minimal base, no AI tool)
   # -------------------------------------------------------------------------
   hi-worker-1:
+    <<: *security
     image: ${WORKER_IMAGE:-achaean-worker:latest}
     container_name: hi-worker-1
     hostname: hi-worker-1


### PR DESCRIPTION
## Summary

- Added `x-security: &security` YAML anchor to both compose files defining `security_opt: [no-new-privileges:true]` and `cap_drop: [ALL]`
- Applied `<<: *security` merge to all 3 services in `docker-compose.claude-only.yml` and all 10 services in `docker-compose.mesh.yml`
- No `cap_add` entries added — none of the current vessel types require any Linux capabilities
- Added **Container Runtime Hardening** section to `SECURITY.md` documenting the options, dropped capabilities table, seccomp deferral note, and `docker inspect` validation command

## Test plan

- [x] YAML validated: `python3 -c "import yaml; yaml.safe_load(open(...))"` passes for both files
- [x] All 13 services confirmed to have `security_opt=['no-new-privileges:true']` and `cap_drop=['ALL']` in parsed YAML
- [ ] Runtime: verify agents start and healthcheck passes after `docker compose up` (requires live API keys and built images)
- [ ] Runtime: `docker inspect <container> | jq '.[0].HostConfig | {SecurityOpt, CapDrop}'` confirms reduced privilege set

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)