### PR TITLE
feat: add OCI image labels for build metadata (commit SHA, build date, version)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,22 @@ jobs:
         with:
           driver: docker
 
+      - name: Set build metadata
+        id: meta
+        run: |
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "vcs_ref=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Build base image
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ${{ matrix.base.dockerfile }}
+          build-args: |
+            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+            VCS_REF=${{ steps.meta.outputs.vcs_ref }}
+            VERSION=${{ steps.meta.outputs.version }}
           push: false
           load: true
           build-args: |
@@ -131,6 +142,13 @@ jobs:
         with:
           driver: docker
 
+      - name: Set build metadata
+        id: meta
+        run: |
+          echo "build_date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+          echo "vcs_ref=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "version=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+
       - name: Build vessel image
         uses: docker/build-push-action@v5
         with:
@@ -138,6 +156,9 @@ jobs:
           file: ${{ matrix.vessel.dockerfile }}
           build-args: |
             BASE_IMAGE=${{ matrix.vessel.base }}:latest
+            BUILD_DATE=${{ steps.meta.outputs.build_date }}
+            VCS_REF=${{ steps.meta.outputs.vcs_ref }}
+            VERSION=${{ steps.meta.outputs.version }}
           push: false
           tags: |
             ${{ matrix.vessel.name }}:latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,11 +68,9 @@ jobs:
             BUILD_DATE=${{ steps.meta.outputs.build_date }}
             VCS_REF=${{ steps.meta.outputs.vcs_ref }}
             VERSION=${{ steps.meta.outputs.version }}
+            GIT_SHA=${{ steps.sha.outputs.short_sha }}
           push: false
           load: true
-          build-args: |
-            GIT_SHA=${{ steps.sha.outputs.short_sha }}
-            VERSION=${{ github.ref_name }}
           tags: |
             ${{ matrix.base.name }}:latest
             ${{ matrix.base.name }}:${{ steps.sha.outputs.short_sha }}

--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -15,6 +15,13 @@ LABEL org.opencontainers.image.revision=$GIT_SHA
 LABEL org.opencontainers.image.version=$VERSION
 LABEL git-sha=$GIT_SHA
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 # Install system dependencies
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -16,6 +16,13 @@ LABEL org.opencontainers.image.revision=$GIT_SHA
 LABEL org.opencontainers.image.version=$VERSION
 LABEL git-sha=$GIT_SHA
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install system dependencies

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -15,6 +15,13 @@ LABEL org.opencontainers.image.revision=$GIT_SHA
 LABEL org.opencontainers.image.version=$VERSION
 LABEL git-sha=$GIT_SHA
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 # Install system dependencies
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \
     curl \

--- a/justfile
+++ b/justfile
@@ -75,11 +75,20 @@ runtime:
 
 # Build all 3 base images
 build-bases:
-    @echo "=== Building base images ({{container_cmd}}) ==="
-    {{container_cmd}} build -f bases/Dockerfile.node    -t achaean-base-node:latest    .
-    {{container_cmd}} build -f bases/Dockerfile.python  -t achaean-base-python:latest  .
-    {{container_cmd}} build -f bases/Dockerfile.minimal -t achaean-base-minimal:latest .
-    @echo "=== Bases built ==="
+    #!/usr/bin/env bash
+    set -euo pipefail
+    container_cmd="$(which podman 2>/dev/null || echo docker)"
+    build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    vcs_ref="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+    version="latest"
+    echo "=== Building base images (${container_cmd}) ==="
+    ${container_cmd} build -f bases/Dockerfile.node    -t achaean-base-node:latest    \
+        --build-arg BUILD_DATE="${build_date}" --build-arg VCS_REF="${vcs_ref}" --build-arg VERSION="${version}" .
+    ${container_cmd} build -f bases/Dockerfile.python  -t achaean-base-python:latest  \
+        --build-arg BUILD_DATE="${build_date}" --build-arg VCS_REF="${vcs_ref}" --build-arg VERSION="${version}" .
+    ${container_cmd} build -f bases/Dockerfile.minimal -t achaean-base-minimal:latest \
+        --build-arg BUILD_DATE="${build_date}" --build-arg VCS_REF="${vcs_ref}" --build-arg VERSION="${version}" .
+    echo "=== Bases built ==="
 
 # Build a single vessel image (builds its base first)
 # Usage: just build-vessel claude
@@ -97,8 +106,13 @@ build-vessel NAME:
     echo "Building base: ${base}"
     ${container_cmd} build -f "bases/Dockerfile.${base#achaean-base-}" -t "${base}:latest" .
     echo "Building vessel: achaean-{{NAME}}"
+    build_date="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    vcs_ref="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
     ${container_cmd} build -f "vessels/{{NAME}}/Dockerfile" \
         --build-arg BASE_IMAGE="${base}:latest" \
+        --build-arg BUILD_DATE="${build_date}" \
+        --build-arg VCS_REF="${vcs_ref}" \
+        --build-arg VERSION="latest" \
         -t "achaean-{{NAME}}:latest" .
     echo "Done: achaean-{{NAME}}:latest"
 
@@ -125,6 +139,19 @@ verify:
         fi
     done
     [ $failed -eq 0 ] && echo "All images verified." || { echo "${failed} image(s) missing. Run: just build-all"; exit 1; }
+
+# Print OCI labels (build metadata) for a named image
+# Usage: just image-info claude
+image-info NAME:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    container_cmd="$(which podman 2>/dev/null || echo docker)"
+    image="achaean-{{NAME}}:latest"
+    echo "=== OCI labels for ${image} ==="
+    ${container_cmd} inspect "${image}" \
+        | jq -r '.[0].Config.Labels | to_entries[] | "\(.key) = \(.value)"' \
+        | grep -E '^org\.opencontainers\.' \
+        || echo "(no OCI labels found — image may not be built yet)"
 
 # =============================================================================
 # Pods (Podman)

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -49,9 +49,15 @@ build_image() {
 # =============================================================================
 echo "=== Building base images ==="
 
-build_image "achaean-base-node:${TAG}"    "bases/Dockerfile.node"
-build_image "achaean-base-python:${TAG}"  "bases/Dockerfile.python"
-build_image "achaean-base-minimal:${TAG}" "bases/Dockerfile.minimal"
+OCI_BUILD_ARGS=(
+    --build-arg "BUILD_DATE=${BUILD_DATE}"
+    --build-arg "VCS_REF=${VCS_REF}"
+    --build-arg "VERSION=${VERSION}"
+)
+
+build_image "achaean-base-node:${TAG}"    "bases/Dockerfile.node"    "${OCI_BUILD_ARGS[@]}"
+build_image "achaean-base-python:${TAG}"  "bases/Dockerfile.python"  "${OCI_BUILD_ARGS[@]}"
+build_image "achaean-base-minimal:${TAG}" "bases/Dockerfile.minimal" "${OCI_BUILD_ARGS[@]}"
 
 # =============================================================================
 # Step 2: Vessel images (each FROM a base via ARG BASE_IMAGE)
@@ -60,19 +66,19 @@ echo ""
 echo "=== Building vessel images ==="
 
 # Node-based vessels
-build_image "achaean-claude:${TAG}"   "vessels/claude/Dockerfile"   --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"
-build_image "achaean-codex:${TAG}"    "vessels/codex/Dockerfile"    --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"
-build_image "achaean-cline:${TAG}"    "vessels/cline/Dockerfile"    --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"
-build_image "achaean-codebuff:${TAG}" "vessels/codebuff/Dockerfile" --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"
-build_image "achaean-ampcode:${TAG}"  "vessels/ampcode/Dockerfile"  --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"
+build_image "achaean-claude:${TAG}"   "vessels/claude/Dockerfile"   --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"   "${OCI_BUILD_ARGS[@]}"
+build_image "achaean-codex:${TAG}"    "vessels/codex/Dockerfile"    --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"   "${OCI_BUILD_ARGS[@]}"
+build_image "achaean-cline:${TAG}"    "vessels/cline/Dockerfile"    --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"   "${OCI_BUILD_ARGS[@]}"
+build_image "achaean-codebuff:${TAG}" "vessels/codebuff/Dockerfile" --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"   "${OCI_BUILD_ARGS[@]}"
+build_image "achaean-ampcode:${TAG}"  "vessels/ampcode/Dockerfile"  --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"   "${OCI_BUILD_ARGS[@]}"
 
 # Python-based vessels
-build_image "achaean-aider:${TAG}" "vessels/aider/Dockerfile" --build-arg "BASE_IMAGE=achaean-base-python:${TAG}"
+build_image "achaean-aider:${TAG}" "vessels/aider/Dockerfile" --build-arg "BASE_IMAGE=achaean-base-python:${TAG}" "${OCI_BUILD_ARGS[@]}"
 
 # Minimal-based vessels
-build_image "achaean-goose:${TAG}"    "vessels/goose/Dockerfile"    --build-arg "BASE_IMAGE=achaean-base-minimal:${TAG}"
-build_image "achaean-opencode:${TAG}" "vessels/opencode/Dockerfile" --build-arg "BASE_IMAGE=achaean-base-minimal:${TAG}"
-build_image "achaean-worker:${TAG}"   "vessels/worker/Dockerfile"   --build-arg "BASE_IMAGE=achaean-base-minimal:${TAG}"
+build_image "achaean-goose:${TAG}"    "vessels/goose/Dockerfile"    --build-arg "BASE_IMAGE=achaean-base-minimal:${TAG}" "${OCI_BUILD_ARGS[@]}"
+build_image "achaean-opencode:${TAG}" "vessels/opencode/Dockerfile" --build-arg "BASE_IMAGE=achaean-base-minimal:${TAG}" "${OCI_BUILD_ARGS[@]}"
+build_image "achaean-worker:${TAG}"   "vessels/worker/Dockerfile"   --build-arg "BASE_IMAGE=achaean-base-minimal:${TAG}" "${OCI_BUILD_ARGS[@]}"
 
 # =============================================================================
 # Summary

--- a/vessels/aider/Dockerfile
+++ b/vessels/aider/Dockerfile
@@ -9,6 +9,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-aider"
 LABEL org.opencontainers.image.description="Aider AI coding assistant vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install aider-chat

--- a/vessels/ampcode/Dockerfile
+++ b/vessels/ampcode/Dockerfile
@@ -8,6 +8,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-ampcode"
 LABEL org.opencontainers.image.description="AmpCode (Sourcegraph Amp) agent vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install AmpCode CLI

--- a/vessels/claude/Dockerfile
+++ b/vessels/claude/Dockerfile
@@ -9,6 +9,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-claude"
 LABEL org.opencontainers.image.description="Claude Code agent vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install Claude Code CLI

--- a/vessels/cline/Dockerfile
+++ b/vessels/cline/Dockerfile
@@ -8,6 +8,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-cline"
 LABEL org.opencontainers.image.description="Cline AI coding agent vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install Cline CLI

--- a/vessels/codebuff/Dockerfile
+++ b/vessels/codebuff/Dockerfile
@@ -8,6 +8,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-codebuff"
 LABEL org.opencontainers.image.description="Codebuff AI coding agent vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install Codebuff CLI

--- a/vessels/codex/Dockerfile
+++ b/vessels/codex/Dockerfile
@@ -8,6 +8,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-codex"
 LABEL org.opencontainers.image.description="OpenAI Codex agent vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install OpenAI Codex CLI

--- a/vessels/goose/Dockerfile
+++ b/vessels/goose/Dockerfile
@@ -27,6 +27,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-goose"
 LABEL org.opencontainers.image.description="Goose (Block) AI agent vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install Goose — pinned version with SHA256 verification (no curl-pipe-bash)

--- a/vessels/opencode/Dockerfile
+++ b/vessels/opencode/Dockerfile
@@ -30,6 +30,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-opencode"
 LABEL org.opencontainers.image.description="OpenCode AI coding agent vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install OpenCode — pinned version with SHA256 verification (no curl-pipe-bash)

--- a/vessels/worker/Dockerfile
+++ b/vessels/worker/Dockerfile
@@ -10,6 +10,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-worker"
 LABEL org.opencontainers.image.description="Shell worker vessel — no AI tool, scripting and utility workloads"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+
 USER root
 
 # Install additional tools useful for shell workers


### PR DESCRIPTION
## Summary

- Add `BUILD_DATE`, `VCS_REF`, and `VERSION` build args + `org.opencontainers.image.created/revision/version` labels to all **3 base** Dockerfiles (`node`, `python`, `minimal`) and all **9 vessel** Dockerfiles
- Update `scripts/build-all.sh` to auto-compute and pass `BUILD_DATE`, `VCS_REF`, and `VERSION` (defaulting to `TAG`) at build time
- Update `justfile` `build-bases` and `build-vessel` recipes to compute and pass OCI build args; add new `image-info <name>` recipe to print OCI labels for any built image
- Update `.github/workflows/ci.yml` to capture build metadata via a `Set build metadata` step and forward it to `docker/build-push-action` in both the `build-bases` and `build-vessels` jobs

## Test plan

- [ ] `just build-bases` and `just build-vessel claude` complete without error
- [ ] `just image-info claude` (or any vessel) prints `org.opencontainers.image.created`, `.revision`, and `.version` labels
- [ ] `docker inspect <image> | jq '.[0].Config.Labels'` shows commit SHA and build date
- [ ] CI workflow passes on this PR (check Actions tab) — base and vessel builds include metadata labels
- [ ] `TAG=v0.1.0 bash scripts/build-all.sh` produces images with `VERSION=v0.1.0` label

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)