### PR TITLE
feat(bases): add shared entrypoint.sh to all base images

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,41 @@ just push   # set REGISTRY=ghcr.io/homericintelligence or override in .env
 23080     hi-worker-1
 ```
 
+## Container startup behavior
+
+All base images ship with `/usr/local/bin/entrypoint.sh` as the `ENTRYPOINT`. The
+script runs in order:
+
+1. **tmux session** — starts a detached tmux session named `$TMUX_SESSION_NAME`
+   (default: `agent-session`). Skipped silently if tmux is unavailable or the
+   session already exists.
+2. **agent-server.js** — if `/app/agent-server.js` is present (bind-mounted at
+   runtime by the Agamemnon agent sidecar), it is exec'd with any extra arguments
+   passed to the container.
+3. **explicit args** — if extra arguments were passed (`docker run <image> <cmd>`
+   or compose `command:`), they are exec'd directly. This means compose overrides
+   work without touching `ENTRYPOINT`.
+4. **fallback shell** — if none of the above apply, `bash` is exec'd. Use
+   `docker run -it <image>` for interactive access.
+
+Every path uses `exec` so the launched process inherits PID 1 and receives
+`SIGTERM`/`SIGINT` from Docker correctly.
+
+### Examples
+
+```bash
+# Default: starts agent-server.js when bind-mounted, otherwise drops to bash
+docker run achaean-claude:latest
+
+# Interactive shell (no agent-server.js mounted)
+docker run -it achaean-claude:latest
+
+# Run an explicit command (overrides fallback but not agent-server.js check)
+docker run achaean-claude:latest node /some/other/script.js
+
+# Compose: no changes required — existing command: directives still work
+```
+
 ## Agamemnon agent sidecar
 
 All containers expect the Agamemnon agent sidecar mounted at `/app/agent-sidecar:ro`.

--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -65,7 +65,7 @@ ENV AGENT_PORT=23001
 ENV GIT_USER_NAME="HomericIntelligence Agent"
 ENV GIT_USER_EMAIL="agent@HomericIntelligence.ai"
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY bases/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 USER agent

--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -65,4 +65,9 @@ ENV AGENT_PORT=23001
 ENV GIT_USER_NAME="HomericIntelligence Agent"
 ENV GIT_USER_EMAIL="agent@HomericIntelligence.ai"
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 USER agent
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -59,7 +59,7 @@ ENV AGENT_PORT=23001
 ENV GIT_USER_NAME="HomericIntelligence Agent"
 ENV GIT_USER_EMAIL="agent@HomericIntelligence.ai"
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY bases/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 USER agent

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -59,4 +59,9 @@ ENV AGENT_PORT=23001
 ENV GIT_USER_NAME="HomericIntelligence Agent"
 ENV GIT_USER_EMAIL="agent@HomericIntelligence.ai"
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 USER agent
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -67,7 +67,7 @@ ENV AGENT_PORT=23001
 ENV GIT_USER_NAME="HomericIntelligence Agent"
 ENV GIT_USER_EMAIL="agent@HomericIntelligence.ai"
 
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY bases/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 
 USER agent

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -67,4 +67,9 @@ ENV AGENT_PORT=23001
 ENV GIT_USER_NAME="HomericIntelligence Agent"
 ENV GIT_USER_EMAIL="agent@HomericIntelligence.ai"
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 USER agent
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/bases/entrypoint.sh
+++ b/bases/entrypoint.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+# AchaeanFleet container entrypoint
+#
+# Startup order:
+#   1. Start a detached tmux session (non-fatal if tmux is unavailable or
+#      a session by that name already exists)
+#   2. If /app/agent-server.js is present (bind-mounted at runtime by the
+#      Agamemnon agent sidecar), exec it with any arguments passed to the
+#      container (compose command: or docker run args).
+#   3. If extra arguments were supplied on the command line, exec them directly.
+#      This lets compose `command:` overrides work without removing ENTRYPOINT.
+#   4. Last resort: drop to an interactive bash shell.
+#
+# Signal handling: every code path uses `exec` so the started process
+# inherits PID 1 and receives SIGTERM/SIGINT from Docker correctly.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# 1. Start tmux session
+# ---------------------------------------------------------------------------
+if command -v tmux &>/dev/null; then
+    tmux new-session -d -s "${TMUX_SESSION_NAME:-agent-session}" 2>/dev/null || true
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Launch agent-server.js if bind-mounted at runtime
+# ---------------------------------------------------------------------------
+if [ -f /app/agent-server.js ]; then
+    exec node /app/agent-server.js "$@"
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Forward any explicit arguments (compose command:, docker run <cmd>)
+# ---------------------------------------------------------------------------
+if [ "$#" -gt 0 ]; then
+    exec "$@"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Fallback: interactive shell
+# ---------------------------------------------------------------------------
+exec bash


### PR DESCRIPTION
## Summary

- Create `bases/entrypoint.sh` — a single shared startup script that: (1) starts a detached tmux session, (2) execs `agent-server.js` if present at `/app/agent-server.js`, (3) forwards explicit `docker run` / compose `command:` args, (4) falls back to `bash`
- Add `COPY entrypoint.sh /usr/local/bin/entrypoint.sh` + `RUN chmod +x` + `ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]` to all three base Dockerfiles (`node`, `python`, `minimal`) so all 9 vessel types inherit defined startup behavior
- Document the startup order and override patterns in `README.md`

## Motivation

Previously, `docker run achaean-claude:latest` dropped into a shell with no agent running. Images were inert without external orchestration — different runtimes (compose, podman pods, Nomad) each had to independently configure the startup command.

## Test plan

- [ ] `docker run achaean-claude:latest` with `/app/agent-server.js` bind-mounted → agent-server.js starts automatically
- [ ] `docker run -it achaean-claude:latest` without agent-server.js → drops to bash
- [ ] `docker run achaean-claude:latest node /some/other/script.js` → runs explicit command
- [ ] `docker compose -f compose/docker-compose.claude-only.yml up -d` → compose deployments unaffected
- [ ] All 9 vessel types (claude, codex, aider, goose, cline, opencode, codebuff, ampcode, worker) build successfully via CI matrix

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)