### PR TITLE
fix(pods): correct containerPort in worker-pod.yaml to AGENT_PORT (23001)

### DIFF
--- a/pods/worker-pod.yaml
+++ b/pods/worker-pod.yaml
@@ -24,7 +24,7 @@ spec:
     - name: worker
       image: achaean-worker:latest
       ports:
-        - containerPort: 23080
+        - containerPort: 23001
           hostPort: 23080
           protocol: TCP
       env:

--- a/tests/test_pod_specs.py
+++ b/tests/test_pod_specs.py
@@ -1,0 +1,46 @@
+"""Regression tests for pod spec port configuration.
+
+Validates that all pod specs in pods/ use containerPort: 23001 (AGENT_PORT)
+and only vary hostPort per the CLAUDE.md port mapping convention.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+PODS_DIR = Path(__file__).parent.parent / "pods"
+AGENT_PORT = 23001
+
+EXPECTED_HOST_PORTS = {
+    "claude-pod.yaml": 23001,
+    "worker-pod.yaml": 23080,
+}
+
+
+def pod_specs() -> list[tuple[str, dict]]:
+    return [(p.name, yaml.safe_load(p.read_text())) for p in sorted(PODS_DIR.glob("*-pod.yaml"))]
+
+
+@pytest.mark.parametrize("filename,spec", pod_specs())
+def test_container_port_is_agent_port(filename: str, spec: dict) -> None:
+    """All containers must listen on AGENT_PORT internally."""
+    for container in spec["spec"]["containers"]:
+        for port in container.get("ports", []):
+            assert port["containerPort"] == AGENT_PORT, (
+                f"{filename}: container '{container['name']}' has "
+                f"containerPort={port['containerPort']}, expected {AGENT_PORT}"
+            )
+
+
+@pytest.mark.parametrize("filename,spec", pod_specs())
+def test_host_port_matches_convention(filename: str, spec: dict) -> None:
+    """hostPort must match the CLAUDE.md port mapping table."""
+    if filename not in EXPECTED_HOST_PORTS:
+        pytest.skip(f"No expected hostPort defined for {filename}")
+    expected = EXPECTED_HOST_PORTS[filename]
+    for container in spec["spec"]["containers"]:
+        for port in container.get("ports", []):
+            assert port["hostPort"] == expected, (
+                f"{filename}: hostPort={port['hostPort']}, expected {expected}"
+            )


### PR DESCRIPTION
## Summary

- `pods/worker-pod.yaml` had `containerPort: 23080` (the hostPort value) instead of the correct `containerPort: 23001` (the internal `AGENT_PORT` all agent vessels listen on)
- `pods/claude-pod.yaml` was already correct — no change needed
- Adds `tests/test_pod_specs.py` as a pytest regression guard to prevent this class of misconfiguration in future pod specs

## Changes

- `pods/worker-pod.yaml`: `containerPort: 23080` → `containerPort: 23001` (hostPort: 23080 unchanged)
- `tests/test_pod_specs.py`: new — validates all pod specs use correct containerPort and hostPort values

## Test plan

- [x] `python -m pytest tests/ -v` — 4 tests pass
- [x] Manual grep confirms both pod specs now have `containerPort: 23001`
- [x] `hostPort` values cross-referenced against CLAUDE.md port mapping table: claude=23001 ✓, worker=23080 ✓

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)