### PR TITLE
fix(pods): add explicit AGENT_PORT env var to worker-pod.yaml

### DIFF
--- a/pods/worker-pod.yaml
+++ b/pods/worker-pod.yaml
@@ -32,6 +32,8 @@ spec:
           value: "http://172.20.0.1:8080"
         - name: AGENT_MODE
           value: "headless"
+        - name: AGENT_PORT
+          value: "23080"
       volumeMounts:
         - name: agent-sidecar
           mountPath: /app/agent-sidecar


### PR DESCRIPTION
## Summary

- Added explicit `AGENT_PORT: "23080"` env var to `pods/worker-pod.yaml`'s `env:` block
- The pod spec was relying on the base image's `ENV AGENT_PORT=23001` default, which was both implicit and incorrect — the worker's actual port is `23080` per the CLAUDE.md port mapping convention
- `containerPort: 23080` and `AGENT_PORT: "23080"` are now consistent and self-documenting

Closes #69

## Test plan

- [x] YAML syntax validated: `python3 -c "import yaml; yaml.safe_load(open('pods/worker-pod.yaml')); print('OK')"`
- [x] `containerPort` and `AGENT_PORT` value confirmed consistent (both `23080`)
- [x] Follows the established pattern from `compose/docker-compose.mesh.yml` and `nomad/mesh.nomad.hcl` where every service explicitly declares `AGENT_PORT`

🤖 Generated with [Claude Code](https://claude.com/claude-code)