### PR TITLE
docs: document CONTAINER_CMD env var for Podman users

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,6 +70,22 @@ just lint
 
 Hooks run automatically on `git commit` after installation.
 
+### Container runtime selection
+
+The justfile auto-detects `podman` if available, otherwise falls back to `docker`.
+To override explicitly, set `CONTAINER_CMD`:
+
+```bash
+# Force Podman
+CONTAINER_CMD=podman just build-all
+
+# Force Docker
+CONTAINER_CMD=docker just build-all
+```
+
+On SELinux-enforcing systems (Fedora, RHEL), Podman rootless works without additional flags —
+the Compose files already include `:Z` volume labels.
+
 ## What You Can Contribute
 
 - **Vessel Dockerfiles** — New agent-specific container images

--- a/README.md
+++ b/README.md
@@ -64,6 +64,26 @@ just test
 just push   # set REGISTRY=ghcr.io/homericintelligence or override in .env
 ```
 
+## Environment variables
+
+| Variable        | Required | Default                          | Purpose                                             |
+|-----------------|----------|----------------------------------|-----------------------------------------------------|
+| `CONTAINER_CMD` | No       | auto-detected (`podman`/`docker`) | Override the container binary                      |
+| `TAG`           | No       | `latest`                         | Image tag applied to all built images               |
+| `REGISTRY`      | No       | `ghcr.io/homericintelligence`    | Registry prefix used by `just push`                 |
+
+**Podman users (Fedora, RHEL):** The justfile auto-detects `podman` if it is on your `PATH`.
+To force a specific binary:
+
+```bash
+CONTAINER_CMD=podman just build-all
+CONTAINER_CMD=podman just build-vessel claude
+```
+
+> **Note:** Podman rootless requires that volume mounts for the Agamemnon sidecar use the `:Z`
+> SELinux label on SELinux-enforcing hosts. The Compose files in `compose/` already include `:Z`
+> where needed.
+
 ## Port mapping
 
 ```


### PR DESCRIPTION
## Summary

- Added an **Environment variables** table to `README.md` (after the "Building images" section) covering `CONTAINER_CMD`, `TAG`, and `REGISTRY` with a Podman one-liner example and SELinux note
- Added a **Container runtime selection** subsection to `CONTRIBUTING.md` (after Verify Your Setup) explaining auto-detection and explicit override via `CONTAINER_CMD`

## Test plan

- [x] `CONTAINER_CMD` now appears in both `README.md` and `CONTRIBUTING.md`
- [x] Documentation follows the existing Markdown standards (language-tagged code blocks, blank lines around blocks and lists)
- [x] No script changes — documentation only per issue scope

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)