### PR TITLE
feat(ci): add Trivy scan for HIGH/CRITICAL CVEs after base image builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,15 @@ jobs:
           load: true
           tags: ${{ matrix.base.name }}:latest
 
+      - name: Scan base image for HIGH/CRITICAL CVEs
+        uses: aquasecurity/trivy-action@0.35.0
+        with:
+          image-ref: ${{ matrix.base.name }}:latest
+          format: table
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+
       - name: Export base image to tarball
         run: docker save ${{ matrix.base.name }}:latest -o /tmp/${{ matrix.base.name }}.tar
 


### PR DESCRIPTION
## Summary

- Adds `aquasecurity/trivy-action@0.35.0` inline in the `build-bases` job, immediately after each base image is loaded into the Docker daemon
- Filters to `--severity HIGH,CRITICAL --ignore-unfixed` — only actionable, fixable findings
- `exit-code: '1'` causes the job to fail on findings, blocking PRs that introduce privilege-escalation CVEs
- Scans all three base images (`achaean-base-node`, `achaean-base-python`, `achaean-base-minimal`) via the existing matrix

## Why not scan vessels too?

The issue targets setuid binaries that survive base image construction. Vessel images only add tool installs on top of a scanned base; if a vessel tool introduced a setuid binary that would be a separate concern. Keeping scope focused on bases as specified in #75.

## Test plan

- [ ] Open a PR touching `bases/` — the `pull_request` trigger is already wired; the new scan step will run for all three base matrix entries
- [ ] Verify each Trivy step exits 0 (0 HIGH/CRITICAL unfixed CVEs) or fails with a table of findings if any exist
- [ ] Confirm vessel builds still run after bases pass (no structural change to the `build-vessels` job)

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)