### PR TITLE
fix(security): strip setuid/setgid bits from base images at build time

### DIFF
--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -75,6 +75,18 @@ RUN git clone https://github.com/ohmyzsh/ohmyzsh.git /home/agent/.oh-my-zsh && \
     cp /home/agent/.oh-my-zsh/templates/zshrc.zsh-template /home/agent/.zshrc
 USER root
 
+# Strip setuid/setgid bits unconditionally at build time.
+# dpkg-statoverride registers overrides so apt upgrades don't re-apply setuid.
+# find strips any additional binaries not tracked by dpkg.
+RUN dpkg-statoverride --update --add root root 0755 /usr/bin/su          2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/newgrp      2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/passwd      2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/chsh        2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/chfn        2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /bin/mount           2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /bin/umount          2>/dev/null || true && \
+    find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true
+
 # Create workspace and app directories
 RUN mkdir -p /workspace /app && \
     chown -R agent:agent /workspace /app

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -61,6 +61,18 @@ RUN git clone https://github.com/ohmyzsh/ohmyzsh.git /home/agent/.oh-my-zsh && \
     cp /home/agent/.oh-my-zsh/templates/zshrc.zsh-template /home/agent/.zshrc
 USER root
 
+# Strip setuid/setgid bits unconditionally at build time.
+# dpkg-statoverride registers overrides so apt upgrades don't re-apply setuid.
+# find strips any additional binaries not tracked by dpkg.
+RUN dpkg-statoverride --update --add root root 0755 /usr/bin/su          2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/newgrp      2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/passwd      2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/chsh        2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/chfn        2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /bin/mount           2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /bin/umount          2>/dev/null || true && \
+    find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true
+
 # Create workspace and app directories
 RUN mkdir -p /workspace /app && \
     chown -R agent:agent /workspace /app

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -71,6 +71,18 @@ USER agent
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 USER root
 
+# Strip setuid/setgid bits unconditionally at build time.
+# dpkg-statoverride registers overrides so apt upgrades don't re-apply setuid.
+# find strips any additional binaries not tracked by dpkg.
+RUN dpkg-statoverride --update --add root root 0755 /usr/bin/su          2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/newgrp      2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/passwd      2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/chsh        2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /usr/bin/chfn        2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /bin/mount           2>/dev/null || true && \
+    dpkg-statoverride --update --add root root 0755 /bin/umount          2>/dev/null || true && \
+    find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true
+
 # Upgrade pip (version pinned for reproducibility — issue #2)
 RUN pip install --upgrade "pip==26.0.1"
 


### PR DESCRIPTION
## Summary

- Adds a `RUN dpkg-statoverride` + `find -perm /6000 -exec chmod a-s` layer to all three base Dockerfiles (`Dockerfile.node`, `Dockerfile.python`, `Dockerfile.minimal`)
- Strips setuid/setgid bits from `su`, `newgrp`, `passwd`, `chsh`, `chfn`, `mount`, and `umount` at build time
- Registers overrides with `dpkg-statoverride` so apt upgrades within the image layer sequence cannot re-apply setuid bits
- `find` sweep catches any additional binaries not tracked by dpkg
- Vessel images inherit the fix automatically — no vessel Dockerfile changes needed

## Why

`cap_drop: ALL` in Compose only guards containers run under Compose. Residual setuid binaries in Debian/Ubuntu base layers (`su`, `newgrp`, `mount`, etc.) remain exploitable when containers are run outside Compose — e.g. standalone CI vessel builds. This fix makes the hardening unconditional by stripping at build time.

Follow-up to #7.

## Test plan

- [ ] Build each base image: `just build-bases`
- [ ] Verify no setuid binaries remain: `docker run --rm achaean-base-node:latest find / -xdev -perm /6000 -type f 2>/dev/null` — expected empty output
- [ ] Spot-check `su`: `docker run --rm achaean-base-node:latest stat -c "%a %n" /usr/bin/su` — expected `755 /usr/bin/su`
- [ ] Repeat checks for `achaean-base-python:latest` and `achaean-base-minimal:latest`
- [ ] Build a vessel (e.g. `just build-vessel claude`) to confirm inheritance works

Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)