### PR TITLE
feat(nomad): add cap_drop=ALL and no_new_privs to all Docker driver configs

### DIFF
--- a/nomad/mesh.nomad.hcl
+++ b/nomad/mesh.nomad.hcl
@@ -66,8 +66,13 @@ job "achaean-mesh" {
       driver = "docker"
 
       config {
-        image = "achaean-claude:latest"
-        ports = ["agent"]
+        image        = "achaean-claude:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
+        # Note: cap_drop ALL compatibility with Claude Code CLI is unverified.
+        # If Claude Code requires specific capabilities (e.g. NET_BIND_SERVICE),
+        # add cap_add = ["NET_BIND_SERVICE"] here after validating with a live run.
 
         volumes = [
           "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
@@ -125,8 +130,10 @@ job "achaean-mesh" {
       driver = "docker"
 
       config {
-        image   = "achaean-aider:latest"
-        ports   = ["agent"]
+        image        = "achaean-aider:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
         volumes = [
           "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
         ]
@@ -173,8 +180,10 @@ job "achaean-mesh" {
       driver = "docker"
 
       config {
-        image   = "achaean-worker:latest"
-        ports   = ["agent"]
+        image        = "achaean-worker:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
         volumes = [
           "/tmp/ci-workspace:/workspace",
           "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",


### PR DESCRIPTION
## Summary

- Adds `cap_drop = ["ALL"]` and `no_new_privs = true` to the Docker driver `config {}` block for all three task groups (`claude`, `aider`, `worker`) in `nomad/mesh.nomad.hcl`
- Achieves security parity with the `cap_drop: [ALL]` / `security_opt: no-new-privileges:true` hardening already present in the Compose files
- Adds a caveat comment on the `claude` task noting that `cap_drop ALL` compatibility with Claude Code CLI is unverified and may require `cap_add` for specific capabilities after live validation

## Test plan

- [ ] Verify `nomad job plan nomad/mesh.nomad.hcl` succeeds without warnings on a Nomad dev agent
- [ ] Confirm containers launch and pass health checks with `cap_drop = ["ALL"]` applied
- [ ] If Claude Code CLI fails to start, add `cap_add = ["NET_BIND_SERVICE"]` (or required capability) per the inline comment

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)