### PR TITLE
feat(ci): add hadolint Dockerfile linting and fix DL4006 violation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,31 @@ on:
       - 'bases/**'
       - 'vessels/**'
       - 'dagger/**'
+      - '.hadolint.yaml'
   pull_request:
     branches: [main]
     paths:
       - 'bases/**'
       - 'vessels/**'
       - 'dagger/**'
+      - '.hadolint.yaml'
 
 jobs:
+  lint-dockerfiles:
+    name: Lint Dockerfiles (hadolint)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run hadolint on all Dockerfiles
+        uses: hadolint/hadolint-action@54c9adbab1582c2ef04b2016b760714a4bfde3cf  # v3.1.0
+        with:
+          recursive: true
+          config: .hadolint.yaml
+
   build-bases:
     name: Build Base Images
     runs-on: ubuntu-latest

--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -1,0 +1,23 @@
+# hadolint configuration for AchaeanFleet Dockerfiles
+#
+# Rules suppressed with rationale:
+#   DL3008 — apt-get without version pins: vessels install tools whose versions
+#             are managed by upstream; pinning would require constant maintenance.
+#   DL3013 — pip without version pins: same rationale as DL3008 for pip.
+#   DL3016 — npm without version pins: same rationale as DL3008 for npm.
+#   DL3059 — multiple consecutive RUN instructions: accepted pattern for
+#             readability when each RUN has a distinct semantic purpose.
+#   SC2312 — consider invoking separately / checking exit code: false-positive
+#             on patterns like `$(curl ...)` used in install one-liners.
+#
+# DL4006/SC2015 (|| true masking exit codes) is intentionally NOT suppressed —
+# that is exactly the class of error this linting job was added to catch.
+
+failure-threshold: warning
+
+ignore:
+  - DL3008
+  - DL3013
+  - DL3016
+  - DL3059
+  - SC2312

--- a/vessels/worker/Dockerfile
+++ b/vessels/worker/Dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update && apt-get install -y \
     jq \
     yq \
     make \
-    && rm -rf /var/lib/apt/lists/* || true
+    && rm -rf /var/lib/apt/lists/*
 
 # Install yq if not available via apt
 RUN which yq || \


### PR DESCRIPTION
## Summary

- Adds a standalone `lint-dockerfiles` job to CI using `hadolint/hadolint-action@v3.1.0` (SHA-pinned), running in parallel with `build-bases`
- Adds `.hadolint.yaml` at repo root with `failure-threshold: warning`; suppresses DL3008/DL3013/DL3016/DL3059/SC2312 but intentionally does **not** suppress DL4006/SC2015
- Fixes the existing DL4006/SC2015 violation in `vessels/worker/Dockerfile` by removing the `|| true` that was masking apt-get errors
- Extends `on.push`/`on.pull_request` path triggers to include `.hadolint.yaml` so config changes re-trigger linting

## Test plan

- [ ] Confirm `lint-dockerfiles` job appears in Actions and passes green
- [ ] Confirm it runs in parallel with `build-bases` (no `needs:` dependency)
- [ ] Confirm `build-vessels` is unaffected (still only depends on `build-bases`)
- [ ] Verify `vessels/worker/Dockerfile` no longer triggers DL4006/SC2015

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)