### PR TITLE
feat(compose): sync hi-vegai into docker-compose.mesh.yml

### DIFF
--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -68,6 +68,24 @@ services:
     restart: unless-stopped
     healthcheck: *healthcheck
 
+  hi-vegai:
+    image: ${CLAUDE_IMAGE:-achaean-claude:latest}
+    container_name: hi-vegai
+    hostname: hi-vegai
+    networks: [homeric-mesh]
+    ports: ["23004:23001"]
+    environment:
+      <<: *common-env
+      AGENT_ID: vegai
+      AGENT_PORT: "23001"
+      TMUX_SESSION_NAME: vegai
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    volumes:
+      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+    working_dir: /workspace
+    restart: unless-stopped
+    healthcheck: *healthcheck
+
   # -------------------------------------------------------------------------
   # Codex agent (Node base)
   # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Added `hi-vegai` Claude agent service (port 23004) to `docker-compose.mesh.yml`, matching its existing definition in `docker-compose.claude-only.yml`
- No functional changes — pure parity fix; environment variables, volume mount, and healthcheck follow the same patterns as `hi-aindrea` and `hi-baird`

## Test plan

- [ ] `docker compose -f compose/docker-compose.mesh.yml config` validates without errors
- [ ] `hi-vegai` service appears in `docker compose -f compose/docker-compose.mesh.yml ps` after `up -d`
- [ ] Port 23004 is mapped correctly and health endpoint responds

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)