### PR TITLE
feat(compose): add hi-eris (23002) and hi-pallas (23005) Claude agent slots

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,10 +69,10 @@ volumes:
 ```
 8080      ProjectAgamemnon coordinator (existing, not in this repo)
 23001     hi-aindrea (claude)
-23002     (unassigned)
+23002     hi-eris (claude)
 23003     hi-baird (claude)
 23004     hi-vegai (claude)
-23005     (unassigned)
+23005     hi-pallas (claude)
 23010     hi-codex-1
 23020     hi-aider-1
 23030     hi-goose-1

--- a/compose/docker-compose.claude-only.yml
+++ b/compose/docker-compose.claude-only.yml
@@ -94,6 +94,34 @@ services:
       retries: 3
 
   # -------------------------------------------------------------------------
+  # Claude agent: Eris (port 23002)
+  # -------------------------------------------------------------------------
+  hi-eris:
+    image: ${CLAUDE_IMAGE:-achaean-claude:latest}
+    container_name: hi-eris
+    hostname: hi-eris
+    networks:
+      - homeric-mesh
+    ports:
+      - "23002:23001"
+    environment:
+      - AGENT_ID=eris
+      - AGENT_PORT=23001
+      - TMUX_SESSION_NAME=eris
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - AGAMEMNON_URL=${AGAMEMNON_URL:-http://172.20.0.1:8080}
+    volumes:
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Eris:/workspace
+    working_dir: /workspace
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:23001/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+  # -------------------------------------------------------------------------
   # Claude agent: Baird (scylla-repo-monitor)
   # -------------------------------------------------------------------------
   hi-baird:
@@ -157,6 +185,34 @@ services:
     logging: *default-logging
     healthcheck:
       test: ["CMD", "curl", "-f", "--cacert", "/certs/ca.crt", "https://caddy:8443/health"]
+      interval: 30s
+      timeout: 5s
+      start_period: 15s
+      retries: 3
+
+  # -------------------------------------------------------------------------
+  # Claude agent: Pallas (port 23005)
+  # -------------------------------------------------------------------------
+  hi-pallas:
+    image: ${CLAUDE_IMAGE:-achaean-claude:latest}
+    container_name: hi-pallas
+    hostname: hi-pallas
+    networks:
+      - homeric-mesh
+    ports:
+      - "23005:23001"
+    environment:
+      - AGENT_ID=pallas
+      - AGENT_PORT=23001
+      - TMUX_SESSION_NAME=pallas
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+      - AGAMEMNON_URL=${AGAMEMNON_URL:-http://172.20.0.1:8080}
+    volumes:
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Pallas:/workspace
+    working_dir: /workspace
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:23001/health"]
       interval: 30s
       timeout: 5s
       start_period: 15s

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -101,6 +101,24 @@ services:
     healthcheck: *healthcheck
     <<: *security
 
+  hi-eris:
+    image: ${CLAUDE_IMAGE:-achaean-claude:latest}
+    container_name: hi-eris
+    hostname: hi-eris
+    networks: [homeric-mesh]
+    ports: ["23002:23001"]
+    environment:
+      <<: *common-env
+      AGENT_ID: eris
+      AGENT_PORT: "23001"
+      TMUX_SESSION_NAME: eris
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    volumes:
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Eris:/workspace
+    working_dir: /workspace
+    restart: unless-stopped
+    healthcheck: *healthcheck
+
   hi-baird:
     <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
@@ -126,6 +144,42 @@ services:
     logging: *default-logging
     healthcheck: *healthcheck
     <<: *security
+
+  hi-vegai:
+    image: ${CLAUDE_IMAGE:-achaean-claude:latest}
+    container_name: hi-vegai
+    hostname: hi-vegai
+    networks: [homeric-mesh]
+    ports: ["23004:23001"]
+    environment:
+      <<: *common-env
+      AGENT_ID: vegai
+      AGENT_PORT: "23001"
+      TMUX_SESSION_NAME: vegai
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    volumes:
+      - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+    working_dir: /workspace
+    restart: unless-stopped
+    healthcheck: *healthcheck
+
+  hi-pallas:
+    image: ${CLAUDE_IMAGE:-achaean-claude:latest}
+    container_name: hi-pallas
+    hostname: hi-pallas
+    networks: [homeric-mesh]
+    ports: ["23005:23001"]
+    environment:
+      <<: *common-env
+      AGENT_ID: pallas
+      AGENT_PORT: "23001"
+      TMUX_SESSION_NAME: pallas
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+    volumes:
+      - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Pallas:/workspace
+    working_dir: /workspace
+    restart: unless-stopped
+    healthcheck: *healthcheck
 
   # -------------------------------------------------------------------------
   # Codex agent (Node base)


### PR DESCRIPTION
## Summary

- Assigns identities to the two reserved-but-undefined Claude agent slots: **hi-eris** (port 23002, `AGENT_ID=eris`) and **hi-pallas** (port 23005, `AGENT_ID=pallas`)
- Both agents added to `docker-compose.claude-only.yml` and `docker-compose.mesh.yml` following existing service definition patterns (block YAML in claude-only, anchor YAML in mesh)
- Also adds **hi-vegai** (port 23004) to `docker-compose.mesh.yml` where it was previously missing
- Port table in `CLAUDE.md` updated: 23002 → `hi-eris (claude)`, 23005 → `hi-pallas (claude)`

## Test plan

- [x] `docker compose -f compose/docker-compose.claude-only.yml config --quiet` — parses cleanly
- [x] `docker compose -f compose/docker-compose.mesh.yml config --quiet` — parses cleanly
- [x] `claude-only` services: hi-aindrea, hi-baird, hi-eris, hi-pallas, hi-vegai (5 agents, port-sequential)
- [x] `mesh` services: all 5 Claude agents + 8 non-Claude agents = 13 total
- [x] No duplicate port bindings
- [x] Healthcheck format uses `["CMD", ...]` array form (not CMD-SHELL)
- [x] CLAUDE.md port table has no remaining `(reserved)` entries in the Claude range

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)