### PR TITLE
feat(ci): gate push-to-registry on Trivy security scan

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ on:
       - 'vessels/**'
       - 'dagger/**'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
 jobs:
   build-bases:
     name: Build Base Images
@@ -115,14 +119,71 @@ jobs:
           push: false
           tags: ${{ matrix.vessel.name }}:latest
 
+      - name: Export vessel image to tarball
+        run: docker save ${{ matrix.vessel.name }}:latest -o /tmp/${{ matrix.vessel.name }}.tar
+
+      - name: Upload vessel image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vessel-image-${{ matrix.vessel.name }}
+          path: /tmp/${{ matrix.vessel.name }}.tar
+          retention-days: 1
+
+  scan-images:
+    name: Security Scan (Trivy)
+    runs-on: ubuntu-latest
+    needs: build-vessels
+    permissions:
+      security-events: write
+    strategy:
+      matrix:
+        vessel:
+          - achaean-claude
+          - achaean-codex
+          - achaean-aider
+          - achaean-goose
+          - achaean-cline
+          - achaean-opencode
+          - achaean-codebuff
+          - achaean-ampcode
+          - achaean-worker
+    steps:
+      - name: Download vessel image artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: vessel-image-${{ matrix.vessel }}
+          path: /tmp
+
+      - name: Load vessel image
+        run: docker load -i /tmp/${{ matrix.vessel }}.tar
+
+      - name: Scan image with Trivy
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: ${{ matrix.vessel }}:latest
+          format: sarif
+          output: trivy-${{ matrix.vessel }}.sarif
+          exit-code: '1'
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+
+      - name: Upload SARIF results
+        if: always()
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.vessel }}.sarif
+          category: trivy-${{ matrix.vessel }}
+
   push-to-registry:
     name: Push to GHCR
     runs-on: ubuntu-latest
-    needs: build-vessels
+    needs: [build-vessels, scan-images]
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     permissions:
       packages: write
       contents: read
+      security-events: write
     env:
       REGISTRY: ghcr.io/homericintelligence
     steps:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,53 @@
+name: Security Audit (Scheduled)
+
+on:
+  schedule:
+    - cron: '0 3 * * 1'
+  workflow_dispatch:
+
+permissions:
+  security-events: write
+  packages: read
+
+jobs:
+  scan-registry-images:
+    name: Audit Registry Image (${{ matrix.image }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        image:
+          - achaean-claude
+          - achaean-codex
+          - achaean-aider
+          - achaean-goose
+          - achaean-cline
+          - achaean-opencode
+          - achaean-codebuff
+          - achaean-ampcode
+          - achaean-worker
+    env:
+      REGISTRY: ghcr.io/homericintelligence
+    steps:
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Scan published image with Trivy
+        uses: aquasecurity/trivy-action@0.30.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ matrix.image }}:latest
+          format: sarif
+          output: trivy-${{ matrix.image }}.sarif
+          exit-code: '0'
+          ignore-unfixed: false
+          severity: UNKNOWN,LOW,MEDIUM,HIGH,CRITICAL
+
+      - name: Upload SARIF results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: trivy-${{ matrix.image }}.sarif
+          category: trivy-scheduled-${{ matrix.image }}


### PR DESCRIPTION
## Summary

- Adds a `scan-images` job in `ci.yml` that runs `aquasecurity/trivy-action@0.30.0` against every built vessel image tarball with `exit-code: '1'`, `ignore-unfixed: true`, and `severity: HIGH,CRITICAL` — a Trivy failure now blocks the push
- `push-to-registry` changes from `needs: build-vessels` → `needs: [build-vessels, scan-images]`, creating a hard technical gate
- `build-vessels` now exports each vessel image as a tarball artifact so `scan-images` can download and load it without rebuilding
- Adds a `concurrency` group at the workflow level to cancel redundant in-flight runs
- Creates `.github/workflows/security.yml` for scheduled weekly + manual Trivy audits of already-published GHCR images (advisory-only, `exit-code: 0`, all severities, SARIF uploaded to GitHub Security tab)

## Test plan

- [ ] Open a PR touching `bases/` or `vessels/` — confirm `scan-images` matrix runs and `push-to-registry` is skipped (PR condition)
- [ ] Merge to `main` — confirm full chain `build-bases → build-vessels → scan-images → push-to-registry` runs in order
- [ ] To verify enforcement: temporarily lower `severity` to `LOW` or inject a known-vulnerable layer; confirm `scan-images` fails and `push-to-registry` does not start
- [ ] Trigger `security.yml` via `workflow_dispatch` — confirm it scans GHCR images and populates the Security → Code scanning tab
- [ ] In repo Settings → Branches → main, add `Security Scan (Trivy) (achaean-*)` as required status checks to make the gate merge-blocking

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)