### PR TITLE
ci: add compose file validation job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,14 +7,33 @@ on:
       - 'bases/**'
       - 'vessels/**'
       - 'dagger/**'
+      - 'compose/**'
   pull_request:
     branches: [main]
     paths:
       - 'bases/**'
       - 'vessels/**'
       - 'dagger/**'
+      - 'compose/**'
 
 jobs:
+  validate-compose:
+    name: Validate Compose Files
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate docker-compose.claude-only.yml
+        run: |
+          docker compose -f compose/docker-compose.claude-only.yml --env-file compose/.env.example config --quiet
+
+      - name: Validate docker-compose.mesh.yml
+        run: |
+          docker compose -f compose/docker-compose.mesh.yml --env-file compose/.env.example config --quiet
+
   build-bases:
     name: Build Base Images
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Adds a `validate-compose` job that runs `docker compose config --quiet` against both compose files on every push/PR touching `compose/**`
- Runs in parallel with `build-bases` (no `needs:` dependency) for fast, lightweight feedback
- Extends `on.push.paths` / `on.pull_request.paths` to include `compose/**` so compose-only changes trigger CI

## Test plan

- [ ] Confirm `validate-compose` appears as a parallel job in the Actions run graph
- [ ] Confirm it completes in under 30s (parse-only, no image pulls)
- [ ] Verify failure detection: introduce a YAML error in a compose file and confirm the job exits non-zero

Both compose files validated locally with exit 0 before this PR.

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)