### PR TITLE
feat(ci): add Dependabot config for GitHub Actions version pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    labels:
+      - dependencies


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with `package-ecosystem: github-actions`
- Configured for weekly updates so action versions like `actions/checkout@v4`, `docker/build-push-action@v5`, `docker/setup-buildx-action@v3`, `docker/login-action@v3`, `actions/upload-artifact@v4`, `actions/download-artifact@v4`, and future `aquasecurity/trivy-action` pins are kept up to date automatically via Dependabot PRs

## Test plan

- [ ] Verify `.github/dependabot.yml` is valid YAML and accepted by GitHub's Dependabot parser
- [ ] After merge, confirm Dependabot creates scheduled PRs for outdated GitHub Actions versions

Closes #93

🤖 Generated with [Claude Code](https://claude.com/claude-code)