### PR TITLE
ci: add Dependabot config for GitHub Actions version pinning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` with `package-ecosystem: github-actions` and `directory: /`
- Configured to run on a weekly schedule
- Surfaces automated PRs whenever pinned action SHAs have new upstream releases, maintaining security pins without manual tracking

## Test plan

- [ ] Confirm `.github/dependabot.yml` is valid YAML and follows the Dependabot v2 schema
- [ ] Verify Dependabot is enabled in the repo's Security settings so the config takes effect
- [ ] After merge, check the Dependabot tab for scheduled update PRs

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)