### PR TITLE
fix(ci): robust docker load tagging via IMAGE_ID capture

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,9 @@ jobs:
           path: /tmp
 
       - name: Load base image into Docker daemon
-        run: docker load -i /tmp/${{ matrix.vessel.base }}.tar
+        run: |
+          IMAGE_ID=$(docker load -i /tmp/${{ matrix.vessel.base }}.tar | awk '{print $NF}')
+          docker tag "$IMAGE_ID" "${{ matrix.vessel.base }}:latest"
 
       - name: Set up Docker Buildx (docker driver — shares daemon image store)
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary

- Replaces the bare `docker load -i <tarball>` command with a two-step pattern that captures the loaded image reference from stdout
- Force-tags the loaded image to `<name>:latest` regardless of what `RepoTags` were embedded in the tarball
- Makes tag failure fatal — no silent fallback that could leave the image loaded but unreachable under the expected name

Fixes the fragility described in #103: `docker load` tags the image using `RepoTags` from the tarball (set by Dagger's export), which may already be `<name>:latest` or may differ. The old bare `docker load` silently left the image orphaned if the embedded tag diverged from the expected name, causing vessel builds to fail with obscure "not found" errors.

**Pattern applied (lines 100-103 of ci.yml):**
```bash
IMAGE_ID=$(docker load -i /tmp/<base>.tar | awk '{print $NF}')
docker tag "$IMAGE_ID" "<base>:latest"
```

`docker load` always prints either `Loaded image: <tag>` or `Loaded image ID: sha256:<digest>` — `awk '{print $NF}'` captures either form. `docker tag` accepts both tags and image IDs as source.

## Test plan

- [ ] Push branch and confirm all 9 `build-vessels` matrix jobs complete without "manifest unknown" or "pull access denied" errors in the "Build vessel image" step
- [ ] Confirm "Load base image into Docker daemon" step exits 0 for each vessel
- [ ] Confirm subsequent vessel builds resolve `BASE_IMAGE=<base>:latest` successfully

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)