### PR TITLE
fix(ci): clean up /tmp tarballs after each pipeline job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,10 @@ jobs:
           path: /tmp/${{ matrix.base.name }}.tar
           retention-days: 1
 
+      - name: Clean up base image tarball
+        if: always()
+        run: rm -f /tmp/${{ matrix.base.name }}.tar
+
   build-vessels:
     name: Build Vessel Images
     runs-on: ubuntu-latest
@@ -114,6 +118,10 @@ jobs:
             BASE_IMAGE=${{ matrix.vessel.base }}:latest
           push: false
           tags: ${{ matrix.vessel.name }}:latest
+
+      - name: Clean up downloaded base image tarball
+        if: always()
+        run: rm -f /tmp/${{ matrix.vessel.base }}.tar
 
   push-to-registry:
     name: Push to GHCR


### PR DESCRIPTION
## Summary

- Adds `rm -f /tmp/<name>.tar` with `if: always()` after the artifact upload step in `build-bases`, so base image tarballs are deleted regardless of prior step success/failure
- Adds `rm -f /tmp/<name>.tar` with `if: always()` after the vessel build step in `build-vessels`, so downloaded base image tarballs are deleted after `docker load` completes

Prevents multi-hundred-MB tarballs from accumulating on long-lived self-hosted runners across repeated workflow runs. `rm -f` is used so the step silently succeeds on ephemeral runners where there's nothing to clean.

Closes #104

## Test plan

- [ ] Push to a branch touching `bases/` and verify the workflow completes — the new cleanup steps should appear in the Actions log
- [ ] Confirm `/tmp/*.tar` files do not persist after the run on a self-hosted runner (or check that the cleanup step output shows the file removed)
- [ ] Trigger a deliberate failure before the upload step and verify `if: always()` fires and cleans up the partial tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)