### PR TITLE
fix(dagger): use per-base-type smoke commands in testImages()

### DIFF
--- a/dagger/pipeline.ts
+++ b/dagger/pipeline.ts
@@ -22,6 +22,13 @@ const BASES = [
   { name: "achaean-base-minimal", dockerfile: "bases/Dockerfile.minimal" },
 ] as const;
 
+// Smoke test commands per base type — node base tests node; python base tests python3; minimal base has neither
+const BASE_SMOKE_CMD: Record<string, string> = {
+  "achaean-base-node":    "tmux -V && git --version && node --version",
+  "achaean-base-python":  "tmux -V && git --version && python3 --version",
+  "achaean-base-minimal": "tmux -V && git --version",
+};
+
 // Vessel image definitions
 const VESSELS = [
   {
@@ -140,9 +147,10 @@ async function testImages(client: Client): Promise<void> {
       buildArgs: [{ name: "BASE_IMAGE", value: `${vessel.base}:latest` }],
     });
 
-    // Basic smoke test: check that required binaries exist
+    // Basic smoke test: check binaries guaranteed by each base type
+    const smokeCmd = BASE_SMOKE_CMD[vessel.base] ?? "tmux -V && git --version";
     const result = await image
-      .withExec(["sh", "-c", "tmux -V && git --version && node --version"])
+      .withExec(["sh", "-c", smokeCmd])
       .stdout();
 
     console.log(`  ${vessel.name} smoke test passed:\n  ${result.trim()}`);


### PR DESCRIPTION
## Summary

- Add `BASE_SMOKE_CMD` map that assigns a smoke test command to each base image type
- `achaean-base-node` → `tmux -V && git --version && node --version`
- `achaean-base-python` → `tmux -V && git --version && python3 --version`
- `achaean-base-minimal` → `tmux -V && git --version`
- Replace the hardcoded `node --version` in `testImages()` with a per-vessel lookup via `vessel.base`

Fixes #105 — python-base (`achaean-aider`) and minimal-base (`achaean-goose`, `achaean-opencode`, `achaean-worker`) vessels no longer run `node --version` in their smoke tests.

## Test plan

- [ ] `npx ts-node dagger/pipeline.ts test` — all 9 vessels pass smoke tests
- [ ] `achaean-aider` runs `python3 --version`, not `node --version`
- [ ] `achaean-goose`, `achaean-opencode`, `achaean-worker` run only `tmux -V && git --version`
- [ ] Node-base vessels (`claude`, `codex`, `cline`, `codebuff`, `ampcode`) still test `node --version`

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)