### PR TITLE
fix(ci): add docker save + non-empty size check for vessel artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Export base image to tarball
         run: docker save ${{ matrix.base.name }}:latest -o /tmp/${{ matrix.base.name }}.tar
 
+      - name: Verify tarball is non-empty
+        run: |
+          [ -s /tmp/${{ matrix.base.name }}.tar ] || \
+            { echo "ERROR: /tmp/${{ matrix.base.name }}.tar is empty or missing"; exit 1; }
+
       - name: Upload base image artifact
         uses: actions/upload-artifact@v4
         with:
@@ -113,7 +118,23 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ matrix.vessel.base }}:latest
           push: false
+          load: true
           tags: ${{ matrix.vessel.name }}:latest
+
+      - name: Export vessel image to tarball
+        run: docker save ${{ matrix.vessel.name }}:latest -o /tmp/${{ matrix.vessel.name }}.tar
+
+      - name: Verify tarball is non-empty
+        run: |
+          [ -s /tmp/${{ matrix.vessel.name }}.tar ] || \
+            { echo "ERROR: /tmp/${{ matrix.vessel.name }}.tar is empty or missing"; exit 1; }
+
+      - name: Upload vessel image artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: vessel-image-${{ matrix.vessel.name }}
+          path: /tmp/${{ matrix.vessel.name }}.tar
+          retention-days: 1
 
   push-to-registry:
     name: Push to GHCR


### PR DESCRIPTION
## Summary

- Adds `[ -s /tmp/<name>.tar ]` size check after `docker save` in both `build-bases` and `build-vessels` jobs — a 0-byte tarball now fails immediately with a clear error message instead of silently propagating to `push-to-registry`
- Adds the missing `docker save` and `actions/upload-artifact` steps to `build-vessels` (the job built the image but never exported it)
- Adds `load: true` to the vessel `docker/build-push-action` step so the daemon has the image available for export

Closes #115

## Test plan

- [ ] CI passes on this PR (build-bases and build-vessels both run without errors)
- [ ] Manually verify: if `docker save` were to produce an empty file, the `Verify tarball is non-empty` step would exit 1 with a clear error message
- [ ] Confirm `push-to-registry` can now find vessel artifacts uploaded by `build-vessels`

🤖 Generated with [Claude Code](https://claude.com/claude-code)