### PR TITLE
ci: add .github/workflows/** and tests/** to paths trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - 'vessels/**'
       - 'dagger/**'
       - 'compose/**'
+      - 'tests/**'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
     paths:
@@ -15,6 +17,8 @@ on:
       - 'vessels/**'
       - 'dagger/**'
       - 'compose/**'
+      - 'tests/**'
+      - '.github/workflows/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}


### PR DESCRIPTION
## Summary
- Added `.github/workflows/**` to the `paths` filter for both `push` and `pull_request` triggers so CI runs when workflow files change
- Also added `tests/**` which was missing from the filter despite being referenced in the CLAUDE.md structure

## Why
Changes to `ci.yml` itself would previously not trigger a CI run, meaning broken workflow syntax could silently merge without validation. This was flagged in issue #116 as a follow-up from #2.

## Test plan
- [ ] Verify that a PR touching `.github/workflows/ci.yml` now triggers CI
- [ ] Verify that a PR touching `tests/` now triggers CI
- [ ] Verify existing paths (`bases/**`, `vessels/**`, `dagger/**`) still trigger CI

Closes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)