### PR TITLE
fix(ci): wire hadolint config and pin YQ_VERSION in worker Dockerfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,61 +40,73 @@ jobs:
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: bases/Dockerfile.node
+          config: .hadolint.yaml
 
       - name: Lint bases/Dockerfile.python
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: bases/Dockerfile.python
+          config: .hadolint.yaml
 
       - name: Lint bases/Dockerfile.minimal
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: bases/Dockerfile.minimal
+          config: .hadolint.yaml
 
       - name: Lint vessels/claude/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/claude/Dockerfile
+          config: .hadolint.yaml
 
       - name: Lint vessels/codex/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/codex/Dockerfile
+          config: .hadolint.yaml
 
       - name: Lint vessels/aider/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/aider/Dockerfile
+          config: .hadolint.yaml
 
       - name: Lint vessels/goose/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/goose/Dockerfile
+          config: .hadolint.yaml
 
       - name: Lint vessels/cline/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/cline/Dockerfile
+          config: .hadolint.yaml
 
       - name: Lint vessels/opencode/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/opencode/Dockerfile
+          config: .hadolint.yaml
 
       - name: Lint vessels/codebuff/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/codebuff/Dockerfile
+          config: .hadolint.yaml
 
       - name: Lint vessels/ampcode/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/ampcode/Dockerfile
+          config: .hadolint.yaml
 
       - name: Lint vessels/worker/Dockerfile
         uses: hadolint/hadolint-action@v3.1.0
         with:
           dockerfile: vessels/worker/Dockerfile
+          config: .hadolint.yaml
 
       - name: Install yamllint
         run: pip install yamllint

--- a/vessels/worker/Dockerfile
+++ b/vessels/worker/Dockerfile
@@ -13,6 +13,7 @@ LABEL org.opencontainers.image.description="Shell worker vessel — no AI tool, 
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
+ARG YQ_VERSION=v4.53.2
 LABEL org.opencontainers.image.created=${BUILD_DATE}
 LABEL org.opencontainers.image.revision=${VCS_REF}
 LABEL org.opencontainers.image.version=${VERSION}


### PR DESCRIPTION
## Summary

- **hadolint-action** was not reading `.hadolint.yaml` — DL3008/DL3015 violations triggered hard failures even though they are intentionally suppressed. Add `config: .hadolint.yaml` to all 12 hadolint steps.
- **`vessels/worker/Dockerfile`** used `${YQ_VERSION}` in a curl URL but never declared the `ARG` — resulting in a 404 at build time. Add `ARG YQ_VERSION=v4.53.2`.

## Test plan

- [ ] `Lint Dockerfiles and YAML` job passes (DL3008/DL3015 suppressed via config)
- [ ] `Smoke Test Worker Vessel` job passes (yq downloads at pinned v4.53.2)
- [ ] `Build Base Images` and `Build Vessel Images` matrix jobs all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)