### PR TITLE
fix(ci): yamllint trailing blank, nomad sensitive attr, goose multiarch base

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -364,6 +364,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: achaean-base-minimal:latest
+          outputs: type=oci,dest=/tmp/achaean-base-minimal.tar
 
       - name: Build goose vessel (amd64 + arm64)
         uses: docker/build-push-action@v5
@@ -373,6 +374,8 @@ jobs:
           platforms: linux/amd64,linux/arm64
           build-args: |
             BASE_IMAGE=achaean-base-minimal:latest
+          build-contexts: |
+            achaean-base-minimal:latest=oci-layout:///tmp/achaean-base-minimal.tar
           push: false
           tags: achaean-goose:latest
 
@@ -485,4 +488,3 @@ jobs:
           echo "| Digest | \`${DIGEST}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "| Commit | \`${COMMIT_SHA}\` |" >> "$GITHUB_STEP_SUMMARY"
           echo "::notice title=Image Digest::${IMAGE_NAME}:latest -> ${DIGEST}"
-

--- a/nomad/mesh.nomad.hcl
+++ b/nomad/mesh.nomad.hcl
@@ -46,14 +46,12 @@ variable "anthropic_api_key" {
   description = "Anthropic API key (for claude, aider, goose, cline, opencode, codebuff, ampcode)"
   type        = string
   default     = ""
-  sensitive   = true
 }
 
 variable "openai_api_key" {
   description = "OpenAI API key (for codex)"
   type        = string
   default     = ""
-  sensitive   = true
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Remove trailing blank line from `ci.yml` — yamllint `empty-lines` (max-end: 0) was failing
- Remove unsupported `sensitive` attribute from `nomad/mesh.nomad.hcl` variable blocks — Nomad 1.9.7 HCL parser rejects it
- Fix Goose Multi-Arch build: use OCI tarball output from base build + `build-contexts` to pass the base to the vessel build, avoiding the "pull access denied for achaean-base-minimal:latest" error

## Test plan
- [ ] Lint YAML passes (no empty-lines error)
- [ ] Validate Nomad Job HCL passes
- [ ] Build Goose Vessel (Multi-Arch) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)