### PR TITLE
test(shell): add TAG env var test case to build-all BATS suite

### DIFF
--- a/tests/shell/scripts/build-all/helpers/common.bash
+++ b/tests/shell/scripts/build-all/helpers/common.bash
@@ -2,6 +2,8 @@ MOCKS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../mocks" && pwd)"
 
 setup_mocks() {
     export PATH="${MOCKS_DIR}:${PATH}"
+    export BUILD_DATE=""
+    export VCS_REF=""
 }
 
 clean_state() {

--- a/tests/shell/scripts/build-all/test_build_all.bats
+++ b/tests/shell/scripts/build-all/test_build_all.bats
@@ -28,3 +28,11 @@ setup() {
     run bash "$SCRIPT"
     [ "$status" -eq 1 ]
 }
+
+@test "TAG env var overrides default image tag" {
+    export TAG="v1.2.3"
+    run bash "$SCRIPT"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"achaean-base-node:v1.2.3"* ]]
+    [[ "$output" == *"achaean-claude:v1.2.3"* ]]
+}


### PR DESCRIPTION
## Summary
Add test case verifying that custom `TAG=v1.2.3` env var is properly passed through to mock build commands in build-all BATS suite.

Also fixes `common.bash` setup_mocks to export required `BUILD_DATE` and `VCS_REF` variables to prevent unbound variable errors.

Closes #293