### PR TITLE
docs(nomad): document ENTRYPOINT override pattern for Nomad job specs

### DIFF
--- a/nomad/PATTERNS.md
+++ b/nomad/PATTERNS.md
@@ -105,6 +105,45 @@ Secrets will be injected via the same `template` mechanism using Vault integrati
 
 ---
 
+## 6. Overriding container ENTRYPOINT and command in Nomad
+
+When you need to override a Docker image's `ENTRYPOINT` or `CMD` in Nomad, use the
+`config` stanza in the task. This is useful for injecting custom startup scripts,
+debugging, or running alternative entry points.
+
+**Key fields:**
+- `entrypoint` — array replacing the image's `ENTRYPOINT` instruction
+- `args` — array replacing the image's `CMD` instruction
+- `command` — NOT the same as `cmd`; use `entrypoint` + `args` instead
+
+```hcl
+task "claude" {
+  driver = "docker"
+  config {
+    image      = "achaean-claude:latest"
+    # Override ENTRYPOINT — use this to inject a custom startup script
+    entrypoint = ["/bin/sh", "/tmp/custom-init.sh"]
+    args       = []
+  }
+}
+```
+
+To run a shell command interactively (useful for debugging), use:
+
+```hcl
+config {
+  image      = "achaean-claude:latest"
+  entrypoint = ["/bin/sh", "-c"]
+  args       = ["echo 'Debug mode' && exec /app/start.sh"]
+}
+```
+
+**Note:** Do not use bare `command` in the `config` stanza — the Docker driver
+interprets `config { command }` as a shorthand for `entrypoint + args` concatenation,
+which is often not what you intend. Always use `entrypoint` and `args` separately for clarity.
+
+---
+
 ## Quick reference — commonly needed Nomad runtime variables
 
 | Variable | Description |


### PR DESCRIPTION
## Summary

Adds comprehensive documentation to `nomad/PATTERNS.md` explaining how to override container ENTRYPOINT and CMD in Nomad job specs using the `config` stanza.

The new section includes:
- Clear explanation of `entrypoint` and `args` fields
- HCL examples showing custom startup script injection
- Debugging patterns with shell command execution
- Important note about avoiding the bare `command` field

Closes #255

## Test plan

- [x] Documentation is clear and follows existing PATTERNS.md style
- [x] HCL examples are syntactically correct
- [x] Guidance matches Nomad Docker driver behavior