### PR TITLE
fix(compose): apply security hardening to hi-eris, hi-vegai, hi-pallas

### DIFF
--- a/compose/docker-compose.claude-only.yml
+++ b/compose/docker-compose.claude-only.yml
@@ -101,25 +101,32 @@ services:
   # Claude agent: Eris (port 23002)
   # -------------------------------------------------------------------------
   hi-eris:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-eris
     hostname: hi-eris
     networks:
-      - homeric-mesh
+      - agamemnon-frontend
     ports:
       - "23002:23001"
     environment:
       - AGENT_ID=eris
       - AGENT_PORT=23001
       - TMUX_SESSION_NAME=eris
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - AGAMEMNON_URL=${AGAMEMNON_URL:-http://172.20.0.1:8080}
+      # ANTHROPIC_API_KEY is injected by entrypoint from /run/secrets/anthropic_api_key
+    secrets:
+      - anthropic_api_key
     volumes:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Eris:/workspace
+      - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
+    read_only: true
+    tmpfs: *tmpfs
     restart: unless-stopped
+    logging: *default-logging
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:23001/health"]
+      test: ["CMD", "curl", "-f", "--cacert", "/certs/ca.crt", "https://caddy:8443/health"]
       interval: 30s
       timeout: 5s
       start_period: 15s
@@ -198,25 +205,32 @@ services:
   # Claude agent: Pallas (port 23005)
   # -------------------------------------------------------------------------
   hi-pallas:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-pallas
     hostname: hi-pallas
     networks:
-      - homeric-mesh
+      - agamemnon-frontend
     ports:
       - "23005:23001"
     environment:
       - AGENT_ID=pallas
       - AGENT_PORT=23001
       - TMUX_SESSION_NAME=pallas
-      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - AGAMEMNON_URL=${AGAMEMNON_URL:-http://172.20.0.1:8080}
+      # ANTHROPIC_API_KEY is injected by entrypoint from /run/secrets/anthropic_api_key
+    secrets:
+      - anthropic_api_key
     volumes:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Pallas:/workspace
+      - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
+    read_only: true
+    tmpfs: *tmpfs
     restart: unless-stopped
+    logging: *default-logging
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:23001/health"]
+      test: ["CMD", "curl", "-f", "--cacert", "/certs/ca.crt", "https://caddy:8443/health"]
       interval: 30s
       timeout: 5s
       start_period: 15s

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -106,21 +106,28 @@ services:
     healthcheck: *healthcheck
 
   hi-eris:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-eris
     hostname: hi-eris
-    networks: [homeric-mesh]
+    networks: [agamemnon-frontend]
     ports: ["23002:23001"]
     environment:
       <<: *common-env
       AGENT_ID: eris
       AGENT_PORT: "23001"
       TMUX_SESSION_NAME: eris
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # ANTHROPIC_API_KEY injected by entrypoint from /run/secrets/anthropic_api_key
+    secrets:
+      - anthropic_api_key
     volumes:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Eris:/workspace
+      - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
+    read_only: true
+    tmpfs: *tmpfs
     restart: unless-stopped
+    logging: *default-logging
     healthcheck: *healthcheck
 
   hi-baird:
@@ -149,39 +156,53 @@ services:
     healthcheck: *healthcheck
 
   hi-vegai:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-vegai
     hostname: hi-vegai
-    networks: [homeric-mesh]
+    networks: [agamemnon-frontend]
     ports: ["23004:23001"]
     environment:
       <<: *common-env
       AGENT_ID: vegai
       AGENT_PORT: "23001"
       TMUX_SESSION_NAME: vegai
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # ANTHROPIC_API_KEY injected by entrypoint from /run/secrets/anthropic_api_key
+    secrets:
+      - anthropic_api_key
     volumes:
       - ${WORKSPACE_ROOT:-/home/mvillmow}:/workspace
+      - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
+    read_only: true
+    tmpfs: *tmpfs
     restart: unless-stopped
+    logging: *default-logging
     healthcheck: *healthcheck
 
   hi-pallas:
+    <<: *security
     image: ${CLAUDE_IMAGE:-achaean-claude:latest}
     container_name: hi-pallas
     hostname: hi-pallas
-    networks: [homeric-mesh]
+    networks: [agamemnon-frontend]
     ports: ["23005:23001"]
     environment:
       <<: *common-env
       AGENT_ID: pallas
       AGENT_PORT: "23001"
       TMUX_SESSION_NAME: pallas
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      # ANTHROPIC_API_KEY injected by entrypoint from /run/secrets/anthropic_api_key
+    secrets:
+      - anthropic_api_key
     volumes:
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Pallas:/workspace
+      - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
+    read_only: true
+    tmpfs: *tmpfs
     restart: unless-stopped
+    logging: *default-logging
     healthcheck: *healthcheck
 
   # -------------------------------------------------------------------------


### PR DESCRIPTION
Closes #136

## Summary
- Apply `<<: *security` anchor to hi-eris, hi-vegai, and hi-pallas in both compose files
- Add read-only root filesystem with tmpfs mounts for writable paths
- Add TLS certificate volume mounts
- Migrate API key injection from plain environment variables to Docker secrets
- Fix network assignments to use agamemnon-frontend
- Add consistent logging and healthchecks with TLS verification

## Changes
**docker-compose.mesh.yml:**
- hi-eris, hi-vegai, hi-pallas: added security hardening (cap_drop: [ALL], no-new-privileges)
- Added tmpfs and read_only settings
- Added secrets integration for anthropic_api_key
- Added TLS cert volumes and logging configuration

**docker-compose.claude-only.yml:**
- hi-eris and hi-pallas: added security hardening
- Fixed network from homeric-mesh to agamemnon-frontend
- Added secrets and TLS cert volume mounts
- Updated healthchecks to use TLS verification

## Test plan
- [ ] Verify docker-compose validation: `docker compose config`
- [ ] Test claude-only startup: `docker compose -f docker-compose.claude-only.yml up -d`
- [ ] Test mesh startup: `docker compose -f docker-compose.mesh.yml up -d`
- [ ] Verify hi-eris, hi-vegai, hi-pallas are healthy
- [ ] Confirm cap_drop:ALL is applied to all three services
- [ ] Confirm read_only filesystem enforcement works

🤖 Generated with Claude Code