### PR TITLE
fix(vessels): add per-port HEALTHCHECK overrides for non-23001 vessels

### DIFF
--- a/vessels/aider/Dockerfile
+++ b/vessels/aider/Dockerfile
@@ -31,3 +31,6 @@ USER agent
 
 ENV AGENT_PROGRAM=aider
 ENV AGENT_HEADLESS_FLAG="--yes --message"
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:23020/health 2>/dev/null || exit 1

--- a/vessels/ampcode/Dockerfile
+++ b/vessels/ampcode/Dockerfile
@@ -27,3 +27,6 @@ USER agent
 
 ENV AGENT_PROGRAM=amp
 ENV AGENT_HEADLESS_FLAG=-x
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:23070/health 2>/dev/null || exit 1

--- a/vessels/cline/Dockerfile
+++ b/vessels/cline/Dockerfile
@@ -27,3 +27,6 @@ USER agent
 
 ENV AGENT_PROGRAM=cline
 ENV AGENT_HEADLESS_FLAG=-y
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:23040/health 2>/dev/null || exit 1

--- a/vessels/codebuff/Dockerfile
+++ b/vessels/codebuff/Dockerfile
@@ -28,3 +28,6 @@ USER agent
 ENV AGENT_PROGRAM=codebuff
 # Codebuff headless mode is configured via SDK; no dedicated flag
 ENV AGENT_HEADLESS_FLAG=""
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:23060/health 2>/dev/null || exit 1

--- a/vessels/codex/Dockerfile
+++ b/vessels/codex/Dockerfile
@@ -27,3 +27,6 @@ USER agent
 
 ENV AGENT_PROGRAM=codex
 ENV AGENT_HEADLESS_FLAG=--yes
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:23010/health 2>/dev/null || exit 1

--- a/vessels/goose/Dockerfile
+++ b/vessels/goose/Dockerfile
@@ -35,3 +35,6 @@ USER agent
 
 ENV AGENT_PROGRAM=goose
 ENV AGENT_HEADLESS_FLAG="--mode cli"
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:23030/health 2>/dev/null || exit 1

--- a/vessels/opencode/Dockerfile
+++ b/vessels/opencode/Dockerfile
@@ -56,3 +56,6 @@ USER agent
 
 ENV AGENT_PROGRAM=opencode
 ENV AGENT_HEADLESS_FLAG=-p
+
+HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
+  CMD wget -qO- http://localhost:23050/health 2>/dev/null || exit 1


### PR DESCRIPTION
## Summary
Adds HEALTHCHECK instruction overrides to 7 vessel Dockerfiles (codex, aider, goose, cline, opencode, codebuff, ampcode) with their respective ports (23010, 23020, 23030, 23040, 23050, 23060, 23070).

Closes #190