### PR TITLE
fix(entrypoint): add bash-to-sh fallback guard for slim base images

### DIFF
--- a/bases/entrypoint.sh
+++ b/bases/entrypoint.sh
@@ -28,5 +28,11 @@ if [ -f /run/secrets/openai_api_key ]; then
     export OPENAI_API_KEY
 fi
 
+# If the command is bash but bash is not available, fall back to sh
+if [ "$1" = "bash" ] && ! command -v bash >/dev/null 2>&1; then
+    shift
+    exec sh "$@"
+fi
+
 # Hand off to the container's CMD (or any arguments passed to docker run)
 exec "$@"


### PR DESCRIPTION
Closes #254

## Summary
Adds a guard in `bases/entrypoint.sh` that checks if the CMD is attempting to exec `bash` but bash is not available (as in slim base images like `python:3.12-slim`). When this condition is detected, the entrypoint falls back to `sh` instead, ensuring containers can still run properly.

## Changes
- Added bash availability check before `exec "$@"` in `bases/entrypoint.sh`
- If `$1 == "bash"` and bash is not on PATH, substitute `sh` as fallback
- Maintains existing behavior when bash is available or when CMD is something else