### PR TITLE
docs(contributing): document DISPATCH_TOKEN required repository secret

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,37 @@ just lint
 
 Hooks run automatically on `git commit` after installation.
 
+### Repository Secrets
+
+The AchaeanFleet CI/CD pipeline uses the following GitHub repository secrets, which must be configured in the repository settings before certain CI jobs will function:
+
+#### DISPATCH_TOKEN
+
+**Required for:** The `notify-proteus` step in the push-to-registry CI job
+
+**What it is:** A personal access token (PAT) with `repo` scope on the [ProjectProteus](https://github.com/HomericIntelligence/ProjectProteus) repository
+
+**Why it's needed:** When AchaeanFleet images are successfully pushed to the registry, the CI pipeline notifies ProjectProteus of the new image versions so the orchestration system can deploy them. Without this token, the notify step silently skips (exits with code 0), giving the false appearance of success while the notification never reaches ProjectProteus.
+
+**How to configure:**
+
+1. Generate a new personal access token on GitHub:
+   - Go to **Settings** → **Developer settings** → **Personal access tokens** → **Tokens (classic)**
+   - Click **Generate new token (classic)**
+   - Give it a descriptive name (e.g., "AchaeanFleet Proteus Notify")
+   - Select the `repo` scope
+   - Copy the token value
+
+2. Add it to AchaeanFleet repository settings:
+   - Go to the [AchaeanFleet repository](https://github.com/HomericIntelligence/AchaeanFleet)
+   - Click **Settings** → **Secrets and variables** → **Actions**
+   - Click **New repository secret**
+   - Name: `DISPATCH_TOKEN`
+   - Value: [paste the token]
+   - Click **Add secret**
+
+**Security note:** This token grants write access to ProjectProteus. Store it securely and never commit it to version control.
+
 ### Container runtime selection
 
 The justfile auto-detects `podman` if available, otherwise falls back to `docker`.


### PR DESCRIPTION
Closes #129

## Summary
Adds documentation for the DISPATCH_TOKEN repository secret, which is required for the CI pipeline's notify-proteus step to function properly. This step notifies ProjectProteus of new image versions after push-to-registry.

## Changes
- Added new "Repository Secrets" subsection in Development Setup
- Documents the purpose of DISPATCH_TOKEN (PAT with repo scope on ProjectProteus)
- Explains the silent failure mode if the secret is missing
- Provides step-by-step instructions for generating and configuring the secret in GitHub Settings

## Why this matters
Without this documentation, contributors may be unaware that the notify step silently skips if the secret is misconfigured, potentially leaving ProjectProteus out of sync with the registry. Clear documentation prevents confusion and deployment issues.