### PR TITLE
fix(compose): add agent-sidecar read-only mount to all vessel services

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -34,6 +34,13 @@ TLS_CERT_DIR=../tls/certs
 TLS_CA_CERT=/certs/ca.crt
 
 # =============================================================================
+# ProjectAgamemnon Agent Sidecar
+# =============================================================================
+# Path to the agent-sidecar binary on the host.
+# Mounted read-only to /app/agent-sidecar inside each container.
+SIDECAR_PATH=/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar
+
+# =============================================================================
 # NATS (forward-looking — required when Hermes/Keystone are integrated)
 # =============================================================================
 NATS_URL=tls://nats:4222

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -114,6 +114,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Aindrea:/workspace
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
@@ -142,6 +143,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Eris:/workspace
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
@@ -170,6 +172,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/ProjectScylla:/workspace
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
@@ -198,6 +201,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Vegai:/workspace
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
@@ -226,6 +230,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Pallas:/workspace
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace
@@ -257,6 +262,7 @@ services:
     secrets:
       - openai_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Codex-1:/workspace
     working_dir: /workspace
     read_only: true
@@ -288,6 +294,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Aider-1:/workspace
     working_dir: /workspace
     read_only: true
@@ -318,6 +325,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Goose-1:/workspace
     working_dir: /workspace
     read_only: true
@@ -349,6 +357,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Cline-1:/workspace
     working_dir: /workspace
     read_only: true
@@ -380,6 +389,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Opencode-1:/workspace
     working_dir: /workspace
     read_only: true
@@ -411,6 +421,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Codebuff-1:/workspace
     working_dir: /workspace
     read_only: true
@@ -442,6 +453,7 @@ services:
     secrets:
       - anthropic_api_key
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - ${WORKSPACE_ROOT:-/home/mvillmow}/Agents/Ampcode-1:/workspace
     working_dir: /workspace
     read_only: true
@@ -475,6 +487,7 @@ services:
       AGENT_PORT: "23001"
       TMUX_SESSION_NAME: worker-1
     volumes:
+      - ${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro
       - /tmp/ci-workspace:/workspace
       - ${TLS_CERT_DIR:-../tls/certs}:/certs:ro
     working_dir: /workspace


### PR DESCRIPTION
Closes #138

## Summary
- Added agent-sidecar read-only mount to all 9 vessel services (claude, codex, aider, goose, cline, opencode, codebuff, ampcode, worker)
- Each service now mounts: `${SIDECAR_PATH:-/home/mvillmow/ProjectAgamemnon/agent-sidecar/agent-sidecar}:/app/agent-sidecar:ro`
- Added SIDECAR_PATH to .env.example with documentation

## Changed Files
- `compose/docker-compose.mesh.yml` — Added sidecar mount to all 14 services (5 Claude agents + 9 other vessel types)
- `compose/.env.example` — Added SIDECAR_PATH variable with default path and documentation

## Why
Per CLAUDE.md, all agents need read-only access to the ProjectAgamemnon agent-sidecar binary to function. This was documented but not fully implemented.