### PR TITLE
ci: add workflow_dispatch force_push input for push-to-registry testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,12 @@ on:
       - 'pixi.lock'
   schedule:
     - cron: '0 6 * * 1'  # Every Monday 06:00 UTC — digest freshness check
+  workflow_dispatch:
+    inputs:
+      force_push:
+        type: boolean
+        default: false
+        description: "Force push-to-registry on non-main branches (for integration testing)"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
@@ -747,7 +753,7 @@ jobs:
     name: Push to GHCR
     runs-on: ubuntu-latest
     needs: [build-vessels]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event.inputs.force_push == 'true'
     permissions:
       packages: write
       contents: read
@@ -877,7 +883,7 @@ jobs:
     name: Verify GHCR Tags
     runs-on: ubuntu-latest
     needs: push-to-registry
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: (github.ref == 'refs/heads/main' && github.event_name == 'push') || github.event.inputs.force_push == 'true'
     timeout-minutes: 10
     permissions:
       packages: read


### PR DESCRIPTION
Closes #117

## Summary
- Added `workflow_dispatch` trigger with `force_push` boolean input (default: false)
- Updated `push-to-registry` job condition to allow manual trigger on non-main branches
- Updated `verify-registry` job condition for consistency

Allows integration testing of the push-to-registry path on feature branches via manual workflow dispatch without permanent code changes.