### PR TITLE
docs(compose): warn security anchors not preserved in override files

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,18 @@ The key will still appear in the child process environment after `exec` in
 `entrypoint.sh`. True process-environment isolation requires each agent tool's
 CLI to read the secret file directly — that is outside the scope of this repo.
 
+### Compose file security overrides
+
+If you use `docker-compose.override.yml` or stack multiple compose files with `-f`,
+be aware that YAML merge anchors (like `<<: *security`) are **not preserved** across
+file boundaries. Override files that redefine `security_opt`, `cap_drop`, or `read_only`
+without repeating all keys will silently drop your security settings.
+
+**Always verify the final config before deploying:**
+```bash
+docker compose -f docker-compose.mesh.yml -f docker-compose.override.yml config | grep -A 2 'security_opt\|cap_drop\|read_only'
+```
+
 ## Agamemnon agent sidecar
 
 All containers expect the Agamemnon agent sidecar mounted at `/app/agent-sidecar:ro`.

--- a/compose/docker-compose.claude-only.yml
+++ b/compose/docker-compose.claude-only.yml
@@ -12,6 +12,12 @@
 #   mkdir -p secrets && echo -n "sk-ant-..." > secrets/anthropic_api_key && chmod 600 secrets/anthropic_api_key
 #   (set SECRETS_DIR in .env if your secrets dir lives elsewhere)
 
+# SECURITY NOTE: If using docker-compose.override.yml or -f stacking, override
+# files must explicitly repeat cap_drop, security_opt, and read_only from the
+# x-security anchor — YAML merge anchors (<<: *security) are not preserved
+# through file-level overrides. Run `docker compose config` to verify security
+# options are present in the final rendered config before deploying.
+
 # Shared security hardening applied to all services
 x-security: &security
   security_opt:

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -36,6 +36,12 @@ secrets:
   openai_api_key:
     file: ${SECRETS_DIR:-./secrets}/openai_api_key
 
+# SECURITY NOTE: If using docker-compose.override.yml or -f stacking, override
+# files must explicitly repeat cap_drop, security_opt, and read_only from the
+# x-security anchor — YAML merge anchors (<<: *security) are not preserved
+# through file-level overrides. Run `docker compose config` to verify security
+# options are present in the final rendered config before deploying.
+
 # Shared security hardening applied to all services
 x-security: &security
   security_opt:


### PR DESCRIPTION
Closes #234

Addresses the security configuration issue described in issue #234.

## Summary

Added security warnings to both compose files and README documentation to alert operators that YAML merge anchors used for security hardening (`cap_drop`, `security_opt`, `read_only`) are **not preserved** when using `docker-compose.override.yml` or `-f` stacking.

## Changes

- Added SECURITY NOTE comments to both `compose/docker-compose.mesh.yml` and `compose/docker-compose.claude-only.yml` (4-5 lines each) warning that overrides must explicitly repeat security keys
- Added "Compose file security overrides" section to README.md under Secret management with an example verification command using `docker compose config`

## Testing

Run `docker compose config` to verify security options are present:
```bash
docker compose -f compose/docker-compose.mesh.yml config | grep -A 2 'security_opt\|cap_drop\|read_only'
```

All YAML files remain valid and parse without errors.

🤖 Generated with Claude Code