### PR TITLE
refactor(bases): extract setuid-strip RUN layer to shared script

### DIFF
--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -58,17 +58,8 @@ USER agent
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 USER root
 
-# Strip setuid/setgid bits unconditionally at build time.
-# dpkg-statoverride registers overrides so apt upgrades don't re-apply setuid.
-# find strips any additional binaries not tracked by dpkg.
-RUN dpkg-statoverride --update --add root root 0755 /usr/bin/su          2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/newgrp      2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/passwd      2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/chsh        2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/chfn        2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /bin/mount           2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /bin/umount          2>/dev/null || true && \
-    find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true
+COPY bases/scripts/strip-setuid.sh /tmp/strip-setuid.sh
+RUN bash /tmp/strip-setuid.sh && rm /tmp/strip-setuid.sh
 
 # Create workspace and app directories
 RUN mkdir -p /workspace /app && \

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -61,17 +61,8 @@ RUN git clone https://github.com/ohmyzsh/ohmyzsh.git /home/agent/.oh-my-zsh && \
     cp /home/agent/.oh-my-zsh/templates/zshrc.zsh-template /home/agent/.zshrc
 USER root
 
-# Strip setuid/setgid bits unconditionally at build time.
-# dpkg-statoverride registers overrides so apt upgrades don't re-apply setuid.
-# find strips any additional binaries not tracked by dpkg.
-RUN dpkg-statoverride --update --add root root 0755 /usr/bin/su          2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/newgrp      2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/passwd      2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/chsh        2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/chfn        2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /bin/mount           2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /bin/umount          2>/dev/null || true && \
-    find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true
+COPY bases/scripts/strip-setuid.sh /tmp/strip-setuid.sh
+RUN bash /tmp/strip-setuid.sh && rm /tmp/strip-setuid.sh
 
 # Create workspace and app directories
 RUN mkdir -p /workspace /app && \

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -57,17 +57,8 @@ USER agent
 RUN sh -c "$(curl -fsSL https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh)" "" --unattended
 USER root
 
-# Strip setuid/setgid bits unconditionally at build time.
-# dpkg-statoverride registers overrides so apt upgrades don't re-apply setuid.
-# find strips any additional binaries not tracked by dpkg.
-RUN dpkg-statoverride --update --add root root 0755 /usr/bin/su          2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/newgrp      2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/passwd      2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/chsh        2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /usr/bin/chfn        2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /bin/mount           2>/dev/null || true && \
-    dpkg-statoverride --update --add root root 0755 /bin/umount          2>/dev/null || true && \
-    find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true
+COPY bases/scripts/strip-setuid.sh /tmp/strip-setuid.sh
+RUN bash /tmp/strip-setuid.sh && rm /tmp/strip-setuid.sh
 
 # Upgrade pip (version pinned for reproducibility — issue #2)
 RUN pip install --upgrade "pip==26.0.1"

--- a/bases/scripts/strip-setuid.sh
+++ b/bases/scripts/strip-setuid.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Strip setuid/setgid bits unconditionally at build time.
+# dpkg-statoverride registers overrides so apt upgrades don't re-apply setuid.
+# find strips any additional binaries not tracked by dpkg.
+
+dpkg-statoverride --update --add root root 0755 /usr/bin/su          2>/dev/null || true
+dpkg-statoverride --update --add root root 0755 /usr/bin/newgrp      2>/dev/null || true
+dpkg-statoverride --update --add root root 0755 /usr/bin/passwd      2>/dev/null || true
+dpkg-statoverride --update --add root root 0755 /usr/bin/chsh        2>/dev/null || true
+dpkg-statoverride --update --add root root 0755 /usr/bin/chfn        2>/dev/null || true
+dpkg-statoverride --update --add root root 0755 /bin/mount           2>/dev/null || true
+dpkg-statoverride --update --add root root 0755 /bin/umount          2>/dev/null || true
+find / -xdev -perm /6000 -type f -exec chmod a-s {} \; 2>/dev/null || true


### PR DESCRIPTION
Closes #303

Consolidates the duplicated 8-line setuid-strip RUN block across three base Dockerfiles into a single shared shell script at `bases/scripts/strip-setuid.sh`.

**Changes:**
- Created `bases/scripts/strip-setuid.sh` with dpkg-statoverride and find commands
- Updated all three base Dockerfiles (node, python, minimal) to COPY and execute the script
- Removed the multi-line RUN blocks from each Dockerfile

This eliminates drift without adding complexity and ensures consistent security hardening across all base images.