### PR TITLE
feat(scripts): add load-secrets.sh for SOPS/age/env secret loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,12 +139,6 @@ echo -n "sk-ant-api03-..." > compose/secrets/anthropic_api_key
 echo -n "sk-proj-..."      > compose/secrets/openai_api_key
 chmod 600 compose/secrets/*
 ```
-LOG_MAX_SIZE=50m   # max size of a single log file (default: 10m)
-LOG_MAX_FILES=5    # number of rotated files to keep (default: 3)
-```
-
-> **WSL2 note:** Without log rotation, 10+ long-running containers can fill the WSL2 virtual disk
-> and make the entire instance unresponsive. Never remove the `logging` block from compose services.
 
 Each container's `entrypoint.sh` reads `/run/secrets/anthropic_api_key` (or
 `openai_api_key`) and exports the value into the environment before handing off
@@ -153,7 +147,27 @@ to the agent. Leave `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` blank in `.env`.
 The `compose/secrets/` directory is gitignored — only the `.gitkeep` placeholder
 is committed.
 
-### Method 2 — Plain environment variables (fallback)
+### Method 2 — Encrypted secrets (SOPS or age)
+
+For teams using secret management tools, use `scripts/load-secrets.sh`:
+
+```bash
+# Decrypt with SOPS (requires encrypted .enc files)
+bash scripts/load-secrets.sh --tool sops
+
+# Decrypt with age (requires ~/.age/key.txt and .enc files)
+bash scripts/load-secrets.sh --tool age
+
+# Load from environment variables
+bash scripts/load-secrets.sh --tool env
+
+# Clean up secrets before shutdown
+bash scripts/load-secrets.sh teardown
+```
+
+See the script for configuration details: `scripts/load-secrets.sh`
+
+### Method 3 — Plain environment variables (fallback)
 
 Set `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` in `compose/.env`. The entrypoint
 falls back to these when the secret files are absent. **Keys will be visible in
@@ -178,6 +192,16 @@ without repeating all keys will silently drop your security settings.
 ```bash
 docker compose -f docker-compose.mesh.yml -f docker-compose.override.yml config | grep -A 2 'security_opt\|cap_drop\|read_only'
 ```
+
+### Logging configuration
+
+```bash
+LOG_MAX_SIZE=50m   # max size of a single log file (default: 10m)
+LOG_MAX_FILES=5    # number of rotated files to keep (default: 3)
+```
+
+> **WSL2 note:** Without log rotation, 10+ long-running containers can fill the WSL2 virtual disk
+> and make the entire instance unresponsive. Never remove the `logging` block from compose services.
 
 ## Agamemnon agent sidecar
 

--- a/scripts/load-secrets.sh
+++ b/scripts/load-secrets.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+# scripts/load-secrets.sh — Load secrets from SOPS, age, or environment
+#
+# Loads ANTHROPIC_API_KEY and OPENAI_API_KEY from encrypted files (SOPS/age)
+# or from environment variables, writing them to compose/secrets/ with 600 mode.
+#
+# Usage:
+#   bash scripts/load-secrets.sh              # Use env method (default)
+#   bash scripts/load-secrets.sh --tool sops  # Decrypt with SOPS
+#   bash scripts/load-secrets.sh --tool age   # Decrypt with age
+#   bash scripts/load-secrets.sh teardown     # Remove secret files
+#
+# Environment variables (for --tool env):
+#   ANTHROPIC_API_KEY
+#   OPENAI_API_KEY
+#
+# For --tool age, expects:
+#   ~/.age/key.txt (age private key)
+#   compose/secrets/anthropic_api_key.enc
+#   compose/secrets/openai_api_key.enc (optional)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+SECRETS_DIR="${REPO_ROOT}/compose/secrets"
+
+# Parse arguments
+TOOL="${1:-env}"
+
+# =============================================================================
+# Helper functions
+# =============================================================================
+
+warn() {
+    echo "⚠️  $*" >&2
+}
+
+die() {
+    echo "❌ Error: $*" >&2
+    exit 1
+}
+
+info() {
+    echo "ℹ️  $*"
+}
+
+# =============================================================================
+# Main logic
+# =============================================================================
+
+mkdir -p "${SECRETS_DIR}"
+
+case "${TOOL}" in
+    teardown)
+        # Remove secret files
+        info "Removing secret files..."
+        rm -f "${SECRETS_DIR}/anthropic_api_key"
+        rm -f "${SECRETS_DIR}/openai_api_key"
+        info "Secrets cleaned up. Remember to securely erase backup copies if they exist."
+        ;;
+
+    env)
+        # Load from environment variables
+        if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+            die "ANTHROPIC_API_KEY not set in environment"
+        fi
+
+        info "Loading secrets from environment..."
+
+        # Write ANTHROPIC_API_KEY
+        echo -n "${ANTHROPIC_API_KEY}" > "${SECRETS_DIR}/anthropic_api_key"
+        chmod 600 "${SECRETS_DIR}/anthropic_api_key"
+        info "Wrote compose/secrets/anthropic_api_key"
+
+        # Write OPENAI_API_KEY if set
+        if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+            echo -n "${OPENAI_API_KEY}" > "${SECRETS_DIR}/openai_api_key"
+            chmod 600 "${SECRETS_DIR}/openai_api_key"
+            info "Wrote compose/secrets/openai_api_key"
+        fi
+
+        warn "Remember to run 'bash scripts/load-secrets.sh teardown' before shutdown to wipe secrets"
+        ;;
+
+    sops)
+        # Decrypt with SOPS
+        if ! command -v sops &> /dev/null; then
+            die "sops not found in PATH. Install it from https://github.com/getsops/sops"
+        fi
+
+        info "Decrypting with SOPS..."
+
+        # Decrypt ANTHROPIC_API_KEY
+        if [[ -f "${SECRETS_DIR}/anthropic_api_key.enc" ]]; then
+            sops -d "${SECRETS_DIR}/anthropic_api_key.enc" > "${SECRETS_DIR}/anthropic_api_key"
+            chmod 600 "${SECRETS_DIR}/anthropic_api_key"
+            info "Wrote compose/secrets/anthropic_api_key"
+        else
+            die "compose/secrets/anthropic_api_key.enc not found"
+        fi
+
+        # Decrypt OPENAI_API_KEY if encrypted file exists
+        if [[ -f "${SECRETS_DIR}/openai_api_key.enc" ]]; then
+            sops -d "${SECRETS_DIR}/openai_api_key.enc" > "${SECRETS_DIR}/openai_api_key"
+            chmod 600 "${SECRETS_DIR}/openai_api_key"
+            info "Wrote compose/secrets/openai_api_key"
+        fi
+
+        warn "Remember to run 'bash scripts/load-secrets.sh teardown' before shutdown to wipe secrets"
+        ;;
+
+    age)
+        # Decrypt with age
+        if ! command -v age &> /dev/null; then
+            die "age not found in PATH. Install it from https://github.com/FiloSottile/age"
+        fi
+
+        AGE_KEY="${HOME}/.age/key.txt"
+        if [[ ! -f "${AGE_KEY}" ]]; then
+            die "age key not found at ${AGE_KEY}"
+        fi
+
+        info "Decrypting with age..."
+
+        # Decrypt ANTHROPIC_API_KEY
+        if [[ -f "${SECRETS_DIR}/anthropic_api_key.enc" ]]; then
+            age -d -i "${AGE_KEY}" "${SECRETS_DIR}/anthropic_api_key.enc" > "${SECRETS_DIR}/anthropic_api_key"
+            chmod 600 "${SECRETS_DIR}/anthropic_api_key"
+            info "Wrote compose/secrets/anthropic_api_key"
+        else
+            die "compose/secrets/anthropic_api_key.enc not found"
+        fi
+
+        # Decrypt OPENAI_API_KEY if encrypted file exists
+        if [[ -f "${SECRETS_DIR}/openai_api_key.enc" ]]; then
+            age -d -i "${AGE_KEY}" "${SECRETS_DIR}/openai_api_key.enc" > "${SECRETS_DIR}/openai_api_key"
+            chmod 600 "${SECRETS_DIR}/openai_api_key"
+            info "Wrote compose/secrets/openai_api_key"
+        fi
+
+        warn "Remember to run 'bash scripts/load-secrets.sh teardown' before shutdown to wipe secrets"
+        ;;
+
+    *)
+        die "Unknown tool: ${TOOL}. Use 'env', 'sops', 'age', or 'teardown'"
+        ;;
+esac
+
+info "Done."


### PR DESCRIPTION
## Summary
Implement issue #227 by adding `scripts/load-secrets.sh` for flexible secret management.

- Supports SOPS, age, and environment variable backends
- Includes teardown command to safely wipe secrets on shutdown
- Follows existing AchaeanFleet script conventions
- Documentation added to README.md with usage examples

Closes #227

## Test plan
- [ ] Run `bash scripts/load-secrets.sh --tool env` with ANTHROPIC_API_KEY set
- [ ] Verify `compose/secrets/anthropic_api_key` created with mode 600
- [ ] Run `bash scripts/load-secrets.sh teardown` and verify files removed
- [ ] Verify script fails gracefully when tool not installed (sops/age)