### PR TITLE
docs(nomad): add Vault secrets guidance for Phase 6 implementation

### DIFF
--- a/nomad/PATTERNS.md
+++ b/nomad/PATTERNS.md
@@ -86,22 +86,47 @@ service {
 
 ---
 
-## 5. Vault secret injection (Phase 6)
+## 5. Secrets Management (Phase 6 Vault Integration)
 
-Secrets will be injected via the same `template` mechanism using Vault integration:
+**Current state (Phases 1–5):**
+API keys and other secrets are **not yet wired** into the Nomad job spec. When Phase 6
+is implemented, secrets must be injected dynamically from Vault, never stored in HCL
+or passed as plain environment variables.
+
+**When implementing (Phase 6+):**
+
+Use the `template` stanza with Consul Template and Vault backend to fetch secrets at
+allocation time:
 
 ```hcl
-# Phase 6: enable after Vault is wired to the Nomad cluster
-# template {
-#   data = <<EOH
-#   {{ with secret "secret/achaean/claude" }}
-#   ANTHROPIC_API_KEY={{ .Data.api_key }}
-#   {{ end }}
-#   EOH
-#   destination = "secrets/env"
-#   env         = true
-# }
+template {
+  data = <<EOH
+{{ with secret "secret/data/homeric/api-keys" }}
+ANTHROPIC_API_KEY={{ .Data.data.anthropic_api_key }}
+{{ end }}
+EOH
+  destination = "secrets/env"
+  env         = true
+}
 ```
+
+**Key rules:**
+- **Never use inline env vars** for secrets (`env { ANTHROPIC_API_KEY = "sk-..." }`)
+- **Never store secrets in HCL** or `.nomadvar` files
+- **Always use `template` with Vault backend** for dynamic secret injection
+- Vault path format: `secret/data/<mount>/<secret-name>` (the `/data/` segment is required)
+- Retrieve fields via `{{ .Data.data.<field-name> }}` (Consul Template syntax)
+
+**Comparison with Docker Compose:**
+The Compose approach uses `secrets` blocks (Docker Secrets or Swarm) or environment
+files with restricted permissions. The Nomad approach is equivalent: Vault provides the
+secret store, and the `template` stanza injects them into the allocation's environment
+at runtime. Both keep secrets out of the image and configuration-as-code.
+
+**Phases 1–5 workaround (if needed temporarily):**
+For development/testing before Vault is available, you may temporarily pass secrets
+via Nomad variable overrides (e.g., `-var="anthropic_api_key=sk-..."` at `nomad job run`
+time). This is acceptable only for dev/test; **production deployments must use Vault**.
 
 ---
 

--- a/nomad/mesh.nomad.hcl
+++ b/nomad/mesh.nomad.hcl
@@ -9,6 +9,11 @@
 #
 # Override variables at run time:
 #   nomad job run -var="agamemnon_url=http://192.168.1.10:8080" nomad/mesh.nomad.hcl
+#
+# SECRETS MANAGEMENT (Phase 6):
+# API keys and dynamic secrets are injected via Nomad's Vault integration.
+# See nomad/PATTERNS.md § 5 for the template stanza pattern and anti-patterns to avoid.
+# Never pass secrets as inline env vars or store them in HCL.
 
 # =============================================================================
 # Variables (override via -var or .nomadvar files)


### PR DESCRIPTION
Closes #228

## Summary
- Adds comprehensive "Secrets Management" section to `nomad/PATTERNS.md` with proper Vault integration pattern
- Explains current state (Phase 6 future work), anti-patterns to avoid, and correct template syntax
- References Docker Compose approach as the mental model
- Includes comment in `mesh.nomad.hcl` pointing to PATTERNS.md for secrets guidance

## Details
- Current state: API keys not yet wired in Nomad job spec
- When implementing: use `template` stanza with Vault backend: `{{ with secret "secret/data/homeric/api-keys" }}{{ .Data.data.anthropic_api_key }}{{ end }}`
- Never use inline env vars or store secrets in HCL
- Optional temporary dev/test workaround using variable overrides (not for production)

## Test plan
- Manual review of updated documentation
- Verify pattern matches Vault/Consul Template syntax
- Confirm reference comment in mesh.nomad.hcl is clear