### PR TITLE
fix(vessels/opencode): remove dead builder stage fetching unpinned latest

### DIFF
--- a/vessels/opencode/Dockerfile
+++ b/vessels/opencode/Dockerfile
@@ -1,33 +1,9 @@
 # AchaeanFleet Vessel: OpenCode
 #
 # Installs OpenCode Go binary on top of the minimal Debian base image.
-# Uses a multi-stage build: the builder stage downloads and extracts the
-# OpenCode binary; only the binary is copied into the runtime image.
 
 ARG BASE_IMAGE=achaean-base-minimal:latest
 
-# Builder stage: download and extract the OpenCode binary
-FROM debian:bookworm-slim AS builder
-
-# Ensure pipefail for piped RUN commands
-SHELL ["/bin/bash", "-o", "pipefail", "-c"]
-
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    curl \
-    ca-certificates \
-    && rm -rf /var/lib/apt/lists/*
-
-# Resolve latest release tag, then download the binary tarball
-RUN OPENCODE_VERSION=$(curl -s https://api.github.com/repos/sst/opencode/releases/latest \
-        | grep '"tag_name"' \
-        | sed 's/.*"tag_name": "\(.*\)".*/\1/') && \
-    curl -fsSL "https://github.com/sst/opencode/releases/download/${OPENCODE_VERSION}/opencode_linux_amd64.tar.gz" \
-        -o /tmp/opencode.tar.gz && \
-    tar -xzf /tmp/opencode.tar.gz -C /tmp && \
-    chmod +x /tmp/opencode && \
-    /tmp/opencode --version || true
-
-# Runtime stage: copy only the binary
 FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.title="achaean-opencode"


### PR DESCRIPTION
Closes #126

The builder stage in vessels/opencode/Dockerfile resolved the OpenCode version via `curl`-ing the GitHub releases API (unpinned), but copied nothing to the runtime image — it was dead code. The runtime stage already installs at the pinned `OPENCODE_VERSION=v1.4.3`.

Removes the dead builder stage entirely.