### PR TITLE
feat(scripts): include vessel digest in notify-proteus dispatch payload

### DIFF
--- a/scripts/notify-proteus.sh
+++ b/scripts/notify-proteus.sh
@@ -10,11 +10,19 @@ ORG=${GITHUB_ORG:-HomericIntelligence}
 REPO=${NOTIFY_REPO:-Myrmidons}
 IMAGE_TAG=${IMAGE_TAG:-latest}
 HOST=${AGAMEMNON_HOST:-hermes}
+VESSEL_DIGEST=${VESSEL_DIGEST:-}
 
 if [ -z "$GITHUB_TOKEN" ]; then
     echo "GITHUB_TOKEN not set — skipping remote dispatch"
     echo "To enable: export GITHUB_TOKEN=<your-token>"
     exit 0
+fi
+
+# Build payload — include vessel_digest only when provided
+if [ -n "$VESSEL_DIGEST" ]; then
+  PAYLOAD="{\"event_type\": \"image-pushed\", \"client_payload\": {\"image_tag\": \"${IMAGE_TAG}\", \"source\": \"AchaeanFleet\", \"host\": \"${HOST}\", \"vessel_digest\": \"${VESSEL_DIGEST}\"}}"
+else
+  PAYLOAD="{\"event_type\": \"image-pushed\", \"client_payload\": {\"image_tag\": \"${IMAGE_TAG}\", \"source\": \"AchaeanFleet\", \"host\": \"${HOST}\"}}"
 fi
 
 echo "Dispatching image-pushed event to ${ORG}/${REPO}..."
@@ -23,7 +31,7 @@ response=$(curl -sf -o /dev/null -w "%{http_code}" \
     -H "Accept: application/vnd.github+json" \
     -H "Authorization: Bearer ${GITHUB_TOKEN}" \
     "https://api.github.com/repos/${ORG}/${REPO}/dispatches" \
-    -d "{\"event_type\": \"image-pushed\", \"client_payload\": {\"image_tag\": \"${IMAGE_TAG}\", \"source\": \"AchaeanFleet\", \"host\": \"${HOST}\"}}")
+    -d "$PAYLOAD")
 
 if [ "$response" = "204" ]; then
     echo "Dispatch sent successfully (HTTP 204)"


### PR DESCRIPTION
Closes #425

Adds optional `VESSEL_DIGEST` env var to `scripts/notify-proteus.sh`. When set (e.g. from the `steps.digest.outputs.digest` CI step output), the digest is included in the `image-pushed` dispatch payload so Myrmidons can pull the exact tested image rather than a floating `:latest` tag.

When unset (manual `just push-and-notify` runs), the payload is unchanged.