### PR TITLE
ci: add node binary ldd compatibility check for all base images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -486,6 +486,15 @@ jobs:
           docker run --rm ${{ matrix.base.name }}:latest test -d /home/agent/.oh-my-zsh
           echo "Base image smoke tests passed."
 
+      - name: Verify node binary shared-lib compatibility
+        run: |
+          docker run --rm --entrypoint sh "${{ matrix.base.name }}:latest" \
+            -c "ldd /usr/local/bin/node" || {
+            echo "ERROR: node binary has missing shared libraries in ${{ matrix.base.name }}"
+            exit 1
+          }
+          echo "node ldd check passed: OK"
+
       - name: Validate base image name is safe
         shell: bash
         run: |


### PR DESCRIPTION
Closes #354

Adds a CI step after the base image smoke tests that runs `ldd /usr/local/bin/node` inside each built base image to verify glibc shared-lib compatibility. If a base OS diverges to a different glibc, the node binary (copied from `node:25-slim`) would fail at runtime — this step catches that at CI time.