### PR TITLE
fix(vessels/goose): remove || true from version check

### DIFF
--- a/vessels/goose/Dockerfile
+++ b/vessels/goose/Dockerfile
@@ -36,7 +36,7 @@ RUN case "${TARGETARCH}" in \
     rm /tmp/goose.tar.gz
 
 # Verify installation
-RUN goose --version || true
+RUN goose --version
 
 USER agent
 


### PR DESCRIPTION
Closes #326

Now that `docker/setup-qemu-action` is set up in the `build-goose-multiarch` CI job, the `|| true` guard on `RUN goose --version` is no longer needed. Removing it means QEMU emulation failures surface as real build errors.