### PR TITLE
ci(build-vessel): verify AI tool binary installed in each vessel

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -611,6 +611,19 @@ jobs:
             echo "WARNING: Expected goose 1.31.1 but got: $goose_ver"
           fi
 
+      - name: Verify AI tool binary is installed
+        run: |
+          AGENT_PROGRAM=$(docker inspect --format '{{range .Config.Env}}{{println .}}{{end}}' \
+            "${{ matrix.vessel.name }}:latest" | grep '^AGENT_PROGRAM=' | cut -d= -f2)
+          if [[ -z "$AGENT_PROGRAM" || "$AGENT_PROGRAM" == "none" ]]; then
+            echo "AGENT_PROGRAM=none or unset — skipping tool binary check (agent-sidecar vessel)"
+            exit 0
+          fi
+          echo "Checking binary: $AGENT_PROGRAM"
+          docker run --rm --entrypoint="" "${{ matrix.vessel.name }}:latest" \
+            sh -c "command -v $AGENT_PROGRAM || { echo 'ERROR: $AGENT_PROGRAM not found'; exit 1; }"
+          echo "Tool binary check passed: $AGENT_PROGRAM is installed"
+
       - name: Verify ENTRYPOINT is set
         run: |
           entrypoint=$(docker inspect "${{ matrix.vessel.name }}:latest" --format '{{json .Config.Entrypoint}}')


### PR DESCRIPTION
Closes #380

Adds a CI step to the `build-vessel` matrix job that reads `AGENT_PROGRAM` from each vessel image ENV and verifies the binary is present via `command -v`. Vessels with `AGENT_PROGRAM=none` (worker — uses agent-sidecar injected at runtime) are explicitly skipped with a log message.