### PR TITLE
fix(vessels): use TARGETARCH for dynamic arch URL in opencode and worker

### DIFF
--- a/vessels/opencode/Dockerfile
+++ b/vessels/opencode/Dockerfile
@@ -20,11 +20,20 @@ LABEL git-sha=${GIT_SHA}
 
 USER root
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG TARGETARCH=amd64
 # Pinned OpenCode version for reproducibility (issue #2). Update ENV to bump.
 ENV OPENCODE_VERSION=v1.4.3
 
 # Install OpenCode binary at pinned version
-RUN curl -fsSL "https://github.com/sst/opencode/releases/download/${OPENCODE_VERSION}/opencode_linux_amd64.tar.gz" \
+# opencode uses x64/arm64 naming (not amd64/arm64)
+RUN case "${TARGETARCH}" in \
+      amd64) OPENCODE_ARCH="x64" ;; \
+      arm64) OPENCODE_ARCH="arm64" ;; \
+      *) echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
+    curl -fsSL "https://github.com/sst/opencode/releases/download/${OPENCODE_VERSION}/opencode-linux-${OPENCODE_ARCH}.tar.gz" \
         -o /tmp/opencode.tar.gz && \
     tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin && \
     chmod +x /usr/local/bin/opencode && \

--- a/vessels/worker/Dockerfile
+++ b/vessels/worker/Dockerfile
@@ -24,12 +24,16 @@ LABEL git-sha=${GIT_SHA}
 
 USER root
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
+ARG TARGETARCH=amd64
+
 # Install required tools — failures here are fatal
 RUN apt-get update && \
     apt-get install -y jq make && \
     rm -rf /var/lib/apt/lists/* && \
     ( which yq || ( \
-        curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+        curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH}" \
             -o /usr/local/bin/yq && \
         chmod +x /usr/local/bin/yq ) )
 


### PR DESCRIPTION
## Summary

- Fix wrong opencode download URL (`opencode_linux_amd64.tar.gz` doesn't exist; correct asset is `opencode-linux-x64.tar.gz` for amd64 and `opencode-linux-arm64.tar.gz` for arm64)
- Replace hardcoded `amd64` in yq download URL with `${TARGETARCH}` in worker Dockerfile
- Add `SHELL ["/bin/bash", "-o", "pipefail", "-c"]` and `ARG TARGETARCH=amd64` to both Dockerfiles

Closes #210

## Test plan

- [ ] CI builds opencode vessel on amd64 (verifies URL fix)
- [ ] CI builds worker vessel on amd64 (verifies yq arch substitution)
- [ ] All 63 pytest pin tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)