### PR TITLE
ci: pin all GitHub Actions to full SHA hashes (supply-chain hardening)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout with full history
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,73 +106,73 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Lint bases/Dockerfile.node
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: bases/Dockerfile.node
           config: .hadolint.yaml
 
       - name: Lint bases/Dockerfile.python
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: bases/Dockerfile.python
           config: .hadolint.yaml
 
       - name: Lint bases/Dockerfile.minimal
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: bases/Dockerfile.minimal
           config: .hadolint.yaml
 
       - name: Lint vessels/claude/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/claude/Dockerfile
           config: .hadolint.yaml
 
       - name: Lint vessels/codex/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/codex/Dockerfile
           config: .hadolint.yaml
 
       - name: Lint vessels/aider/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/aider/Dockerfile
           config: .hadolint.yaml
 
       - name: Lint vessels/goose/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/goose/Dockerfile
           config: .hadolint.yaml
 
       - name: Lint vessels/cline/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/cline/Dockerfile
           config: .hadolint.yaml
 
       - name: Lint vessels/opencode/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/opencode/Dockerfile
           config: .hadolint.yaml
 
       - name: Lint vessels/codebuff/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/codebuff/Dockerfile
           config: .hadolint.yaml
 
       - name: Lint vessels/ampcode/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/ampcode/Dockerfile
           config: .hadolint.yaml
 
       - name: Lint vessels/worker/Dockerfile
-        uses: hadolint/hadolint-action@v3.3.0
+        uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5  # v3.3.0
         with:
           dockerfile: vessels/worker/Dockerfile
           config: .hadolint.yaml

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -28,7 +28,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
         with:
           fetch-depth: 0
 
@@ -55,7 +55,7 @@ jobs:
           severity: HIGH,CRITICAL
 
       - name: Upload Trivy SARIF results
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@ce64ddcb0d8d890d2df4a9d1c04ff297367dea2a  # v3
         if: always()
         with:
           sarif_file: trivy-results.sarif
@@ -69,7 +69,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
       - name: Pull and scan base images
         run: |
           for img in achaean-base-node achaean-base-python achaean-base-minimal; do

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -15,7 +15,7 @@ jobs:
     name: BATS shell tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
 
       - name: Install bats-core
         run: sudo apt-get install -y bats

--- a/.github/workflows/verify-checksums.yml
+++ b/.github/workflows/verify-checksums.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
 
       - name: Verify goose checksum
         run: |


### PR DESCRIPTION
## Summary

- Replaces mutable version tags with immutable commit SHAs across all workflow files
- `actions/checkout@v4` → SHA in changelog.yml, shell-tests.yml, verify-checksums.yml, security.yml
- `hadolint/hadolint-action@v3.3.0` → SHA (12 uses in ci.yml)
- `github/codeql-action/upload-sarif@v3` → SHA in security.yml

Closes #357

## Test plan

- [ ] CI passes (YAML lint + all jobs)
- [ ] Action SHAs resolve correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)