### PR TITLE
feat(ci): add TLS cert distribution to Nomad client hosts

### DIFF
--- a/.github/workflows/certs.yml
+++ b/.github/workflows/certs.yml
@@ -1,0 +1,56 @@
+name: Distribute TLS certs to Nomad clients
+
+# Required secrets (configure in repo settings before this workflow runs):
+#   NOMAD_SSH_DEPLOY_KEY     — base64-encoded ed25519 private key (nomad user on each client)
+#   NOMAD_CLIENT_KNOWN_HOSTS — base64-encoded ssh known_hosts file covering all client hosts
+#   NOMAD_CLIENT_HOSTS       — space-separated list of Nomad client hostnames or IPs
+#
+# See tls/README.md for setup instructions.
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  distribute:
+    name: Generate and distribute TLS certs
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
+
+      - name: Decode SSH credentials
+        env:
+          DEPLOY_KEY_B64: ${{ secrets.NOMAD_SSH_DEPLOY_KEY }}
+          KNOWN_HOSTS_B64: ${{ secrets.NOMAD_CLIENT_KNOWN_HOSTS }}
+        run: |
+          umask 077
+          mkdir -p /tmp/sshcreds
+          printf '%s' "$DEPLOY_KEY_B64" | base64 -d > /tmp/sshcreds/deploy_key
+          printf '%s' "$KNOWN_HOSTS_B64" | base64 -d > /tmp/sshcreds/known_hosts
+          chmod 600 /tmp/sshcreds/deploy_key
+
+      - name: Generate TLS certs
+        run: bash tls/generate-certs.sh
+
+      - name: Distribute certs to Nomad client hosts
+        env:
+          NOMAD_CLIENT_HOSTS: ${{ secrets.NOMAD_CLIENT_HOSTS }}
+          CERT_SRC_DIR: ${{ github.workspace }}/tls/certs
+          CERT_DEST_DIR: /etc/achaean/certs
+          SSH_KEY_FILE: /tmp/sshcreds/deploy_key
+          SSH_KNOWN_HOSTS_FILE: /tmp/sshcreds/known_hosts
+        run: bash scripts/distribute-certs.sh
+
+      - name: Scrub credentials and private keys
+        if: always()
+        run: |
+          rm -rf /tmp/sshcreds
+          rm -f tls/certs/ca.key tls/certs/caddy.key tls/certs/nats.key

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -719,6 +719,13 @@ if bad: print('\n'.join(bad))
           ignore-unfixed: true
           severity: HIGH,CRITICAL
 
+  distribute-certs:
+    name: Distribute TLS certs (main only)
+    needs: [build-vessels]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    uses: ./.github/workflows/certs.yml
+    secrets: inherit
+
   test-smoke:
     name: Smoke Test Worker Vessel
     runs-on: ubuntu-latest

--- a/nomad/mesh.nomad.hcl
+++ b/nomad/mesh.nomad.hcl
@@ -37,6 +37,12 @@ variable "workspace_root" {
   default     = "/home/mvillmow"
 }
 
+variable "tls_cert_dir" {
+  description = "Absolute path to TLS certificate directory on Nomad client hosts (populated by .github/workflows/certs.yml)"
+  type        = string
+  default     = "/etc/achaean/certs"
+}
+
 
 # =============================================================================
 # Job
@@ -82,6 +88,7 @@ job "achaean-mesh" {
 
         volumes = [
           "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
         ]
       }
 
@@ -154,6 +161,7 @@ EOT
         no_new_privs = true
         volumes = [
           "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
         ]
       }
 
@@ -217,6 +225,7 @@ EOT
         volumes = [
           "/tmp/ci-workspace:/workspace",
           "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
         ]
       }
 

--- a/scripts/distribute-certs.sh
+++ b/scripts/distribute-certs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Distribute TLS certs to Nomad client hosts via SCP.
+#
+# Copies ca.crt, caddy.{crt,key}, nats.{crt,key} from $CERT_SRC_DIR to
+# $CERT_DEST_DIR on each host, then sets correct permissions (600 *.key, 644 *.crt).
+#
+# Required env:
+#   NOMAD_CLIENT_HOSTS       space-separated hostnames or IPs
+#   CERT_SRC_DIR             local directory containing the cert files
+#   SSH_KEY_FILE             path to the ed25519 deploy private key
+#   SSH_KNOWN_HOSTS_FILE     path to an ssh known_hosts file (no StrictHostKeyChecking=no)
+#
+# Optional env:
+#   CERT_DEST_DIR   destination directory on each host (default: /etc/achaean/certs)
+#   SSH_USER        remote user (default: nomad)
+
+set -euo pipefail
+
+: "${NOMAD_CLIENT_HOSTS:?NOMAD_CLIENT_HOSTS is required}"
+: "${CERT_SRC_DIR:?CERT_SRC_DIR is required}"
+: "${SSH_KEY_FILE:?SSH_KEY_FILE is required}"
+: "${SSH_KNOWN_HOSTS_FILE:?SSH_KNOWN_HOSTS_FILE is required}"
+
+CERT_DEST_DIR="${CERT_DEST_DIR:-/etc/achaean/certs}"
+SSH_USER="${SSH_USER:-nomad}"
+
+SSH_OPTS="-i ${SSH_KEY_FILE} -o UserKnownHostsFile=${SSH_KNOWN_HOSTS_FILE} -o BatchMode=yes -o ConnectTimeout=10"
+
+ERRORS=0
+
+for host in $NOMAD_CLIENT_HOSTS; do
+  echo "==> ${host}"
+
+  # shellcheck disable=SC2086
+  if ! ssh $SSH_OPTS "${SSH_USER}@${host}" "sudo mkdir -p ${CERT_DEST_DIR}"; then
+    echo "ERROR: ${host}: failed to create ${CERT_DEST_DIR}"
+    ERRORS=$((ERRORS + 1))
+    continue
+  fi
+
+  for f in ca.crt caddy.crt caddy.key nats.crt nats.key; do
+    # Stage to /tmp first — SCP doesn't need root; sudo mv into dest
+    # shellcheck disable=SC2086
+    if ! scp $SSH_OPTS "${CERT_SRC_DIR}/${f}" "${SSH_USER}@${host}:/tmp/${f}"; then
+      echo "ERROR: ${host}: scp failed for ${f}"
+      ERRORS=$((ERRORS + 1))
+      continue 2
+    fi
+    # shellcheck disable=SC2086
+    if ! ssh $SSH_OPTS "${SSH_USER}@${host}" "sudo mv /tmp/${f} ${CERT_DEST_DIR}/${f}"; then
+      echo "ERROR: ${host}: mv /tmp/${f} -> ${CERT_DEST_DIR}/${f} failed"
+      ERRORS=$((ERRORS + 1))
+      continue 2
+    fi
+  done
+
+  # shellcheck disable=SC2086
+  if ! ssh $SSH_OPTS "${SSH_USER}@${host}" \
+      "sudo chmod 600 ${CERT_DEST_DIR}/caddy.key ${CERT_DEST_DIR}/nats.key && \
+       sudo chmod 644 ${CERT_DEST_DIR}/ca.crt ${CERT_DEST_DIR}/caddy.crt ${CERT_DEST_DIR}/nats.crt"; then
+    echo "ERROR: ${host}: chmod failed"
+    ERRORS=$((ERRORS + 1))
+  fi
+
+  echo "    OK: ${host}"
+done
+
+if [[ $ERRORS -gt 0 ]]; then
+  echo "FAILED: ${ERRORS} host(s) reported errors"
+  exit 1
+fi
+
+echo "OK: certs distributed to all hosts"

--- a/tls/README.md
+++ b/tls/README.md
@@ -130,6 +130,45 @@ nats pub -s "tls://localhost:4222" \
   test.subject "hello"
 ```
 
+## CI distribution to Nomad client hosts
+
+Certs generated locally with `bash tls/generate-certs.sh` are for development. In CI,
+`.github/workflows/certs.yml` regenerates and distributes them on every push to `main`
+via `scripts/distribute-certs.sh`.
+
+Required GitHub Actions secrets:
+
+| Secret | Format | Purpose |
+|---|---|---|
+| `NOMAD_SSH_DEPLOY_KEY` | base64 of an ed25519 private key | Authenticates to each Nomad client host as the `nomad` user |
+| `NOMAD_CLIENT_KNOWN_HOSTS` | base64 of an ssh `known_hosts` file | Pre-enrolls host fingerprints; avoids `StrictHostKeyChecking=no` |
+| `NOMAD_CLIENT_HOSTS` | space-separated hostnames or IPs | Targets for cert distribution |
+
+Generate the deploy key and encode secrets:
+
+```bash
+# Generate a new deploy key
+ssh-keygen -t ed25519 -a 64 -f ~/.ssh/nomad_deploy -N ""
+
+# Base64-encode for GitHub secrets
+base64 -w0 ~/.ssh/nomad_deploy        # → NOMAD_SSH_DEPLOY_KEY
+ssh-keyscan -t ed25519 host1 host2 ... | base64 -w0  # → NOMAD_CLIENT_KNOWN_HOSTS
+```
+
+Set via GitHub CLI:
+
+```bash
+gh secret set NOMAD_SSH_DEPLOY_KEY     --body "$(base64 -w0 ~/.ssh/nomad_deploy)"
+gh secret set NOMAD_CLIENT_KNOWN_HOSTS --body "$(ssh-keyscan -t ed25519 host1 host2 | base64 -w0)"
+gh secret set NOMAD_CLIENT_HOSTS       --body "host1 host2 host3"
+```
+
+Once secrets are provisioned, manually trigger a test run:
+
+```bash
+gh workflow run certs.yml
+```
+
 ## Tailscale Alternative
 
 If the homeric-mesh runs entirely on Tailscale-connected hosts, WireGuard provides


### PR DESCRIPTION
## Summary

- Adds `scripts/distribute-certs.sh` — SCP-based cert distributor for Nomad client hosts with error-accumulator pattern (no `|| true`)
- Adds `.github/workflows/certs.yml` — reusable workflow (generates certs via existing `tls/generate-certs.sh`, distributes them, scrubs private keys)
- Wires `distribute-certs` job into `ci.yml` after `build-vessels`, gated to `main`-push only
- Adds `variable "tls_cert_dir"` to `nomad/mesh.nomad.hcl` and bind-mounts it read-only at `/certs` in all three task groups
- Documents required secrets and setup procedure in `tls/README.md`

**Note:** The issue body asserted that `var.tls_cert_dir` already existed in the Nomad HCL — it did not. This PR adds it.

## Secrets checklist (required before the workflow runs successfully)

- [ ] `NOMAD_SSH_DEPLOY_KEY` — `base64 -w0 ~/.ssh/nomad_deploy` (ed25519 key)
- [ ] `NOMAD_CLIENT_KNOWN_HOSTS` — `ssh-keyscan -t ed25519 host1 host2 ... | base64 -w0`
- [ ] `NOMAD_CLIENT_HOSTS` — space-separated hostnames/IPs of Nomad client hosts

Set all three with:
```bash
gh secret set NOMAD_SSH_DEPLOY_KEY     --body "$(base64 -w0 ~/.ssh/nomad_deploy)"
gh secret set NOMAD_CLIENT_KNOWN_HOSTS --body "$(ssh-keyscan -t ed25519 host1 | base64 -w0)"
gh secret set NOMAD_CLIENT_HOSTS       --body "host1 host2"
```

The `distribute-certs` job will fail on the first post-merge push until these secrets are provisioned. That failure is expected and will not block other CI jobs (no downstream job depends on it yet).

## Test plan

- [ ] CI jobs `validate`, `lint`, `shell-tests` pass on this PR
- [ ] `shellcheck --severity=warning scripts/distribute-certs.sh` passes
- [ ] After merge: provision the three secrets, run `gh workflow run certs.yml`, confirm each Nomad client host has `/etc/achaean/certs/*.{crt,key}` with correct permissions

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)