### PR TITLE
fix(ci): fix YAML parse error in digest-bump workflow

### DIFF
--- a/.github/workflows/digest-bump.yml
+++ b/.github/workflows/digest-bump.yml
@@ -129,21 +129,24 @@ jobs:
 
       - name: Create pull request
         if: steps.check_changes.outputs.no_changes == 'false'
-        run: |
-          gh pr create \
-            --title "chore: monthly base image digest bump" \
-            --body "Automated monthly digest bump for base images.
-
-Updates pinned digests in:
-- bases/Dockerfile.node
-- bases/Dockerfile.python
-- bases/Dockerfile.minimal
-
-Closes #128" \
-            --head "$BRANCH_NAME" \
-            --base main
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          printf '%s\n' \
+            "Automated monthly digest bump for base images." \
+            "" \
+            "Updates pinned digests in:" \
+            "- bases/Dockerfile.node" \
+            "- bases/Dockerfile.python" \
+            "- bases/Dockerfile.minimal" \
+            "" \
+            "Closes #128" \
+            > /tmp/pr-body.txt
+          gh pr create \
+            --title "chore: monthly base image digest bump" \
+            --body-file /tmp/pr-body.txt \
+            --head "$BRANCH_NAME" \
+            --base main
 
       - name: Exit successfully
         if: steps.check_changes.outputs.no_changes == 'true'


### PR DESCRIPTION
## Summary

`digest-bump.yml` has been failing with "workflow file issue" since it was created. The `gh pr create --body "..."` multiline string in the `Create pull request` step has content lines at column 0 (`Updates pinned digests in:`, `Closes #128`), which breaks YAML literal block scalar parsing — same root cause as the `ci.yml` fix in #553.

**Fix:** Replace inline multiline `--body` with `--body-file`, writing the PR body to `/tmp/pr-body.txt` via `printf` (all lines properly indented within the `run: |` block).

Verified: `python3 -c "import yaml; yaml.safe_load(open('digest-bump.yml'))"` → no parse errors.

## Test plan

- [ ] `digest-bump.yml` workflow no longer reports "workflow file issue"
- [ ] `Create pull request` step produces correct PR body (can verify with `workflow_dispatch`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)