### PR TITLE
fix(ci): fix yamllint line-length and goose multi-arch OCI lock error

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,8 +348,16 @@ jobs:
 
       - name: Assert security hardening in all compose services
         run: |
+          printf '%s\n' \
+            'import yaml,os,sys' \
+            'f=os.environ["CF"]' \
+            'd=yaml.safe_load(open(f))' \
+            's=d.get("services",{})' \
+            'bad=[k for k in s if "cap_drop" not in str(s[k])]' \
+            'print("\n".join(bad))' \
+            > /tmp/cap_drop_check.py
           for f in compose/docker-compose.claude-only.yml compose/docker-compose.mesh.yml; do
-            missing=$(python3 -c "import yaml,sys; d=yaml.safe_load(open('${f}')); s=d.get('services',{}); bad=[k for k in s if 'cap_drop' not in str(s[k])]; print('\n'.join(bad))")
+            missing=$(CF="$f" python3 /tmp/cap_drop_check.py)
             if [[ -n "$missing" ]]; then
               echo "ERROR: services missing cap_drop in $f:"
               echo "$missing"
@@ -816,6 +824,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v3.3.0
+
+      - name: Clean OCI output directory before build
+        run: rm -rf /tmp/achaean-base-minimal
 
       - name: Build minimal base (amd64 + arm64)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0


### PR DESCRIPTION
## Summary

Two failures in `Build All Agent Images` on main:

**1. yamllint `line-length` error (ci.yml line 352)**

The single-line `python3 -c "..."` fix from PR #553 (replacing the column-0 multiline block) produced a 181-character line, exceeding yamllint's 160-char limit. Fix: write the Python script to `/tmp/cap_drop_check.py` via `printf` in the `run:` block, then invoke it with the filename passed via a `CF` env var.

**2. Goose multi-arch OCI lock error**

`build-goose-multiarch` was failing with:
```
oci-layout:///tmp/achaean-base-minimal could not be resolved:
could not lock /tmp/achaean-base-minimal/index.json.lock: not a directory
```
A prior Docker buildx step left a stale directory at `/tmp/achaean-base-minimal`. Fix: add `rm -rf /tmp/achaean-base-minimal` before the base build step to guarantee a clean OCI output directory.

## Test plan

- [ ] `Lint Dockerfiles and YAML / Lint YAML files` passes (no yamllint errors)
- [ ] `Build Goose Vessel (Multi-Arch)` passes end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)