### PR TITLE
fix(ci): fix OCI dest trailing slash and compose validate caddy overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -348,8 +348,16 @@ jobs:
 
       - name: Assert security hardening in all compose services
         run: |
+          printf '%s\n' \
+            'import yaml,os,sys' \
+            'f=os.environ["CF"]' \
+            'd=yaml.safe_load(open(f))' \
+            's=d.get("services",{})' \
+            'bad=[k for k in s if "cap_drop" not in str(s[k])]' \
+            'print("\n".join(bad))' \
+            > /tmp/cap_drop_check.py
           for f in compose/docker-compose.claude-only.yml compose/docker-compose.mesh.yml; do
-            missing=$(python3 -c "import yaml,sys; d=yaml.safe_load(open('${f}')); s=d.get('services',{}); bad=[k for k in s if 'cap_drop' not in str(s[k])]; print('\n'.join(bad))")
+            missing=$(CF="$f" python3 /tmp/cap_drop_check.py)
             if [[ -n "$missing" ]]; then
               echo "ERROR: services missing cap_drop in $f:"
               echo "$missing"
@@ -816,6 +824,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v3.3.0
+
+      - name: Clean OCI output directory before build
+        run: rm -rf /tmp/achaean-base-minimal
 
       - name: Build minimal base (amd64 + arm64)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -244,7 +244,11 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Validate claude-only compose
-        run: docker compose -f compose/docker-compose.claude-only.yml config --quiet
+        run: |
+          docker compose \
+            -f compose/docker-compose.caddy.yml \
+            -f compose/docker-compose.claude-only.yml \
+            config --quiet
 
       - name: Validate mesh compose
         run: docker compose -f compose/docker-compose.mesh.yml config --quiet
@@ -836,7 +840,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: achaean-base-minimal:latest
-          outputs: type=oci,dest=/tmp/achaean-base-minimal
+          outputs: type=oci,dest=/tmp/achaean-base-minimal/
 
       - name: Build goose vessel (amd64 + arm64)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
@@ -868,7 +872,7 @@ jobs:
 
       - name: Clean up OCI layout directory
         if: always()
-        run: rm -rf /tmp/achaean-base-minimal
+        run: rm -rf /tmp/achaean-base-minimal/
 
   push-to-registry:
     name: Push to GHCR


### PR DESCRIPTION
## Summary

Two more failures in `Build All Agent Images`:

**1. Goose multi-arch OCI directory format**

`outputs: type=oci,dest=/tmp/achaean-base-minimal` (no trailing slash) writes a **tarball**, not an OCI directory. The `build-contexts` reference `oci-layout:///tmp/achaean-base-minimal` expects a **directory**, causing:
```
could not lock /tmp/achaean-base-minimal/index.json.lock: not a directory
```
Fix: add trailing slash → `dest=/tmp/achaean-base-minimal/` forces OCI layout directory output.

**2. Validate Compose — undefined service `caddy`**

`docker compose -f docker-compose.claude-only.yml config --quiet` fails with:
```
service "hi-eris" depends on undefined service "caddy": invalid compose project
```
`caddy` is defined in the `docker-compose.caddy.yml` overlay — it must be included in the validate command (matching the usage documented in CLAUDE.md).

Fix: `docker compose -f compose/docker-compose.caddy.yml -f compose/docker-compose.claude-only.yml config --quiet`

Verified locally: passes with only a deprecation warning on the `version` attribute.

## Test plan

- [ ] `Build Goose Vessel (Multi-Arch)` passes
- [ ] `Validate Compose Files / Validate claude-only compose` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)