### PR TITLE
fix(ci): add caddy overlay to all remaining compose validate steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -251,7 +251,11 @@ jobs:
             config --quiet
 
       - name: Validate mesh compose
-        run: docker compose -f compose/docker-compose.mesh.yml config --quiet
+        run: |
+          docker compose \
+            -f compose/docker-compose.caddy.yml \
+            -f compose/docker-compose.mesh.yml \
+            config --quiet
 
       - name: Reject bare WORKSPACE_ROOT workspace mounts
         run: |
@@ -308,15 +312,27 @@ jobs:
       - name: Validate compose services have logging configured
         run: |
           # Verify all services have logging configured (count should equal service count)
-          claude_services=$(docker compose -f compose/docker-compose.claude-only.yml config --services | wc -l | tr -d ' ')
-          claude_count=$(docker compose -f compose/docker-compose.claude-only.yml config | grep -c "max-size" || true)
+          claude_services=$(docker compose \
+            -f compose/docker-compose.caddy.yml \
+            -f compose/docker-compose.claude-only.yml \
+            config --services | wc -l | tr -d ' ')
+          claude_count=$(docker compose \
+            -f compose/docker-compose.caddy.yml \
+            -f compose/docker-compose.claude-only.yml \
+            config | grep -c "max-size" || true)
           if [[ $claude_count -lt $claude_services ]]; then
             echo "ERROR: claude-only has $claude_services services but only $claude_count have logging configured"
             exit 1
           fi
 
-          mesh_services=$(docker compose -f compose/docker-compose.mesh.yml config --services | wc -l | tr -d ' ')
-          mesh_count=$(docker compose -f compose/docker-compose.mesh.yml config | grep -c "max-size" || true)
+          mesh_services=$(docker compose \
+            -f compose/docker-compose.caddy.yml \
+            -f compose/docker-compose.mesh.yml \
+            config --services | wc -l | tr -d ' ')
+          mesh_count=$(docker compose \
+            -f compose/docker-compose.caddy.yml \
+            -f compose/docker-compose.mesh.yml \
+            config | grep -c "max-size" || true)
           if [[ $mesh_count -lt $mesh_services ]]; then
             echo "ERROR: mesh has $mesh_services services but only $mesh_count have logging configured"
             exit 1
@@ -353,17 +369,24 @@ jobs:
       - name: Assert security hardening in all compose services
         run: |
           printf '%s\n' \
-            'import yaml,os,sys' \
-            'f=os.environ["CF"]' \
-            'd=yaml.safe_load(open(f))' \
+            'import yaml,sys' \
+            'd=yaml.safe_load(sys.stdin)' \
             's=d.get("services",{})' \
             'bad=[k for k in s if "cap_drop" not in str(s[k])]' \
             'print("\n".join(bad))' \
             > /tmp/cap_drop_check.py
-          for f in compose/docker-compose.claude-only.yml compose/docker-compose.mesh.yml; do
-            missing=$(CF="$f" python3 /tmp/cap_drop_check.py)
+          declare -A LABELS=(
+            ["claude-only"]="compose/docker-compose.claude-only.yml"
+            ["mesh"]="compose/docker-compose.mesh.yml"
+          )
+          for label in claude-only mesh; do
+            f="${LABELS[$label]}"
+            missing=$(docker compose \
+              -f compose/docker-compose.caddy.yml \
+              -f "$f" \
+              config | python3 /tmp/cap_drop_check.py)
             if [[ -n "$missing" ]]; then
-              echo "ERROR: services missing cap_drop in $f:"
+              echo "ERROR: services missing cap_drop in $label:"
               echo "$missing"
               exit 1
             fi
@@ -372,8 +395,14 @@ jobs:
 
       - name: Verify secrets not hardcoded in compose config
         run: |
-          ANTHROPIC_API_KEY=dummy OPENAI_API_KEY=dummy docker compose -f compose/docker-compose.claude-only.yml config > /tmp/claude-only-config.yml
-          ANTHROPIC_API_KEY=dummy OPENAI_API_KEY=dummy docker compose -f compose/docker-compose.mesh.yml config > /tmp/mesh-config.yml
+          ANTHROPIC_API_KEY=dummy OPENAI_API_KEY=dummy docker compose \
+            -f compose/docker-compose.caddy.yml \
+            -f compose/docker-compose.claude-only.yml \
+            config > /tmp/claude-only-config.yml
+          ANTHROPIC_API_KEY=dummy OPENAI_API_KEY=dummy docker compose \
+            -f compose/docker-compose.caddy.yml \
+            -f compose/docker-compose.mesh.yml \
+            config > /tmp/mesh-config.yml
 
           # ANTHROPIC_API_KEY must come from Docker secrets (not env), so it should
           # never appear as a literal value in the expanded config. OPENAI_API_KEY is

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -858,8 +858,8 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v3.3.0
 
-      - name: Clean OCI output directory before build
-        run: rm -rf /tmp/achaean-base-minimal
+      - name: Clean OCI output paths before build
+        run: rm -rf /tmp/achaean-base-minimal.tar /tmp/achaean-base-minimal
 
       - name: Build minimal base (amd64 + arm64)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
@@ -869,7 +869,12 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: false
           tags: achaean-base-minimal:latest
-          outputs: type=oci,dest=/tmp/achaean-base-minimal/
+          outputs: type=oci,dest=/tmp/achaean-base-minimal.tar
+
+      - name: Extract OCI tarball to layout directory
+        run: |
+          mkdir -p /tmp/achaean-base-minimal
+          tar -xf /tmp/achaean-base-minimal.tar -C /tmp/achaean-base-minimal
 
       - name: Build goose vessel (amd64 + arm64)
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
@@ -884,24 +889,9 @@ jobs:
           push: false
           tags: achaean-goose:latest
 
-      - name: Export vessel image to tarball
-        run: docker save ${{ matrix.vessel.name }}:latest -o /tmp/${{ matrix.vessel.name }}.tar
-
-      - name: Verify tarball is non-empty
-        run: |
-          [ -s /tmp/${{ matrix.vessel.name }}.tar ] || \
-            { echo "ERROR: /tmp/${{ matrix.vessel.name }}.tar is empty or missing"; exit 1; }
-
-      - name: Upload vessel image artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
-        with:
-          name: vessel-image-${{ matrix.vessel.name }}
-          path: /tmp/${{ matrix.vessel.name }}.tar
-          retention-days: 7
-
       - name: Clean up OCI layout directory
         if: always()
-        run: rm -rf /tmp/achaean-base-minimal/
+        run: rm -rf /tmp/achaean-base-minimal.tar /tmp/achaean-base-minimal
 
   push-to-registry:
     name: Push to GHCR


### PR DESCRIPTION
## Summary

**Fix 1: Caddy overlay for all compose validate steps**
- All \`docker compose config\` calls in the \`validate\` job now include \`-f compose/docker-compose.caddy.yml\` as the first file
- Affects three steps: \`Validate compose services have logging configured\`, \`Assert security hardening in all compose services\`, \`Verify secrets not hardcoded in compose config\`
- Refactors the \`cap_drop\` security check to use \`docker compose config\` piped to the Python checker via stdin, so multi-file merges resolve correctly

**Fix 2: Goose multi-arch OCI export**
- \`type=oci,dest=/path/\` (trailing slash) causes buildx to try writing a tarball to a directory path → \`open /tmp/achaean-base-minimal/: is a directory\` error
- New approach: export as \`/tmp/achaean-base-minimal.tar\` (no slash → tarball), then \`tar -xf\` to a directory, then reference with \`oci-layout:///tmp/achaean-base-minimal\`
- Also removes stale \`\${{ matrix.vessel.name }}\` references — this is a non-matrix job

## Why

- Caddy: \`docker-compose.claude-only.yml\` and \`.mesh.yml\` define services with \`depends_on: caddy\`, but caddy is only in \`docker-compose.caddy.yml\`; without the overlay, \`docker compose config\` exits with "undefined service caddy"
- Goose: buildx \`type=oci\` always writes a tarball; trailing slash makes the action pre-create the destination as a directory, causing the tar-write to fail

## Test Plan

- [ ] CI \`Validate Compose Files\` job passes
- [ ] CI \`Build Goose Vessel (Multi-Arch)\` job passes
- [ ] All other jobs remain green

🤖 Generated with [Claude Code](https://claude.com/claude-code)