### PR TITLE
fix(ci): remove hardcoded default from BUILDARCH ARG in goose Dockerfile

### DIFF
--- a/vessels/goose/Dockerfile
+++ b/vessels/goose/Dockerfile
@@ -36,8 +36,8 @@ RUN case "${TARGETARCH}" in \
     rm /tmp/goose.tar.gz
 
 # Verify installation (native arch only — cross-arch QEMU emulation cannot execute arm64 binaries)
-ARG BUILDARCH=amd64
-RUN if [ "${TARGETARCH}" = "${BUILDARCH}" ]; then goose --version; else echo "Skipping goose --version: cross-arch build (${BUILDARCH} → ${TARGETARCH})"; fi
+ARG BUILDARCH
+RUN if [ "${TARGETARCH}" = "${BUILDARCH}" ]; then goose --version; else echo "Skipping goose --version: cross-arch build (${BUILDARCH} -> ${TARGETARCH})"; fi
 
 USER agent
 


### PR DESCRIPTION
## Summary

`BUILDARCH` is a Docker automatic platform ARG — declaring it as `ARG BUILDARCH=amd64` overrides the value buildx would set automatically, so arm64 builds would still see `BUILDARCH=amd64` and the conditional `goose --version` skip would not trigger correctly.

Changed to `ARG BUILDARCH` (no default) so buildx provides the correct build-host architecture at build time.

Also replaced non-ASCII `→` with ASCII `->` in the echo message.

## Test Plan

- [ ] CI `Build Goose Vessel (Multi-Arch)` passes — goose --version runs on amd64, skipped on arm64

🤖 Generated with [Claude Code](https://claude.com/claude-code)