### PR TITLE
fix(ci): handle empty BUILDARCH in goose cross-arch version check

### DIFF
--- a/vessels/goose/Dockerfile
+++ b/vessels/goose/Dockerfile
@@ -37,7 +37,7 @@ RUN case "${TARGETARCH}" in \
 
 # Verify installation (native arch only — cross-arch QEMU emulation cannot execute arm64 binaries)
 ARG BUILDARCH
-RUN if [ "${TARGETARCH}" = "${BUILDARCH}" ]; then goose --version; else echo "Skipping goose --version: cross-arch build (${BUILDARCH} -> ${TARGETARCH})"; fi
+RUN if [ -z "${BUILDARCH}" ] || [ "${TARGETARCH}" = "${BUILDARCH}" ]; then goose --version; else echo "Skipping goose --version: cross-arch build (${BUILDARCH} -> ${TARGETARCH})"; fi
 
 USER agent
 


### PR DESCRIPTION
## Summary

When building single-platform (without `--platform` flag), Docker buildx may not populate `BUILDARCH`. In that case the ARG resolves to empty string, causing `[ "amd64" = "" ]` → false → the version check would be skipped even on native builds.

Fix: treat empty `BUILDARCH` as native-arch build so `goose --version` runs when BUILDARCH is unset.

```dockerfile
# Before:
RUN if [ "${TARGETARCH}" = "${BUILDARCH}" ]; then goose --version; ...
# After:
RUN if [ -z "${BUILDARCH}" ] || [ "${TARGETARCH}" = "${BUILDARCH}" ]; then goose --version; ...
```

## Test Plan

- [ ] CI `Build Goose Vessel (Multi-Arch)` passes (arm64 skips, amd64 runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)