### PR TITLE
fix(ci): remove TARGETARCH default so buildx sets correct arch for arm64 slice

### DIFF
--- a/vessels/goose/Dockerfile
+++ b/vessels/goose/Dockerfile
@@ -17,7 +17,7 @@ USER root
 # Ensure pipefail for piped RUN commands
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG TARGETARCH=amd64
+ARG TARGETARCH
 ARG GOOSE_VERSION=1.31.1
 ENV GOOSE_VERSION=1.31.1
 ARG GOOSE_AMD64_SHA256=61c072e843428310abc9751abb4bab097ce2721e519539fb22f0a4a29c8d02da


### PR DESCRIPTION
## Root Cause

`ARG TARGETARCH=amd64` in `vessels/goose/Dockerfile` causes **both** the amd64 and arm64 build slices to see `TARGETARCH=amd64`. Docker's automatic platform ARGs only override user-declared ARGs when there is **no default value**. With `=amd64` as the default, the arm64 slice gets `TARGETARCH=amd64` → downloads the x86_64 binary → installs amd64 binary into an arm64 container → `goose --version` exits 127 (wrong binary arch).

## Fix

Change `ARG TARGETARCH=amd64` → `ARG TARGETARCH` (no default). Buildx then sets `TARGETARCH=arm64` for the arm64 slice, so the correct `aarch64` tarball is downloaded and installed.

## Evidence

From CI logs:
```
#8 [linux/arm64->amd64 1/3] RUN case "amd64" in ...   ← TARGETARCH was "amd64" for arm64 slice
```
Expected after fix:
```
#8 [linux/arm64->amd64 1/3] RUN case "arm64" in ...   ← TARGETARCH should be "arm64"
```

## Test Plan

- [ ] CI `Build Goose Vessel (Multi-Arch)` passes — arm64 slice downloads aarch64 tarball, goose --version skipped (QEMU), amd64 slice passes version check

🤖 Generated with [Claude Code](https://claude.com/claude-code)