### PR TITLE
fix(ci): correct opencode v1.4.3 download URL

### DIFF
--- a/.github/workflows/verify-checksums.yml
+++ b/.github/workflows/verify-checksums.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           echo "Verifying opencode-1.4.3-linux-x64.sha256..."
           EXPECTED_HASH=$(cat scripts/checksums/opencode-1.4.3-linux-x64.sha256 | tr -d ' ')
-          curl -fsSL "https://github.com/sst/opencode/releases/download/v1.4.3/opencode_linux_amd64.tar.gz" \
+          curl -fsSL "https://github.com/sst/opencode/releases/download/v1.4.3/opencode-linux-x64.tar.gz" \
             -o /tmp/opencode.tar.gz
           ACTUAL_HASH=$(sha256sum /tmp/opencode.tar.gz | awk '{print $1}')
           echo "Expected: $EXPECTED_HASH"


### PR DESCRIPTION
## Summary

- The `verify-checksums` workflow was downloading `opencode_linux_amd64.tar.gz` which does not exist as a release asset for v1.4.3, causing a 404 and CI failure
- The correct asset name uses hyphens and x64 notation: `opencode-linux-x64.tar.gz`
- The stored checksum file (`scripts/checksums/opencode-1.4.3-linux-x64.sha256`) already references the correct filename — only the download URL in the workflow was wrong

## Test plan

- [ ] Verify the `Verify Checksums` workflow passes on this PR
- [ ] Confirm the curl download resolves successfully for the corrected URL
- [ ] Confirm the sha256 hash matches the stored checksum

🤖 Generated with [Claude Code](https://claude.com/claude-code)