### PR TITLE
chore: gitignore worktrees, coverage, and scheduled task lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,12 @@ __pycache__/
 
 # Local test outputs
 /tmp/
+
+# Coverage reports
+.coverage
+.coverage.*
+
+# Claude worktree and session artifacts
+.worktrees/
+.claude/worktrees/
+.claude/scheduled_tasks.lock


### PR DESCRIPTION
Prevents .worktrees/, .claude/worktrees/, .coverage, and .claude/scheduled_tasks.lock from appearing as untracked files after parallel agent sessions.