### PR TITLE
ci: merge typecheck steps into lint job, reformat markdown docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,8 @@ of success while the notification never reaches ProjectProteus.
    - Value: [paste the token]
    - Click **Add secret**
 
-**Security note:** This token grants write access to ProjectProteus. Store it securely and never commit it to version control.
+**Security note:** This token grants write access to ProjectProteus. Store it securely and never
+commit it to version control.
 
 ### Container runtime selection
 
@@ -356,10 +357,14 @@ them with SHA256 checksums to ensure reproducibility and security. When updating
 
    ```bash
    # For AMD64
-   curl -fsSL "https://github.com/block/goose/releases/download/v1.32.0/goose-x86_64-unknown-linux-gnu.tar.gz" | sha256sum
+   curl -fsSL \
+     "https://github.com/block/goose/releases/download/v1.32.0/goose-x86_64-unknown-linux-gnu.tar.gz" \
+     | sha256sum
 
    # For ARM64
-   curl -fsSL "https://github.com/block/goose/releases/download/v1.32.0/goose-aarch64-unknown-linux-gnu.tar.gz" | sha256sum
+   curl -fsSL \
+     "https://github.com/block/goose/releases/download/v1.32.0/goose-aarch64-unknown-linux-gnu.tar.gz" \
+     | sha256sum
    ```
 
 1. **Update the ARG values** in the relevant Dockerfile:
@@ -377,7 +382,8 @@ them with SHA256 checksums to ensure reproducibility and security. When updating
 
 ## Checksum Rotation
 
-For tools installed via binary downloads (Goose, OpenCode, YQ), AchaeanFleet provides an automated recipe to handle version bumps and checksum updates atomically.
+For tools installed via binary downloads (Goose, OpenCode, YQ), AchaeanFleet provides an automated
+recipe to handle version bumps and checksum updates atomically.
 
 ### Using `just rotate-checksum`
 
@@ -514,7 +520,8 @@ This is a **manual configuration step** — it is not automated by the workflow 
 4. Search for and enable each required check listed above
 5. Save the rule
 
-These checks prevent merging code that fails security or quality gates and ensure all artifacts meet the project's standards.
+These checks prevent merging code that fails security or quality gates and ensure all artifacts meet
+the project's standards.
 
 ### Never Push Directly to Main
 
@@ -549,9 +556,11 @@ When preparing a release (typically before major deployments or after significan
 
 ### Why CalVer for AchaeanFleet?
 
-- **Date-bound deployments**: Container images are tied to specific deployment dates, making incident investigation and rollback more intuitive
+- **Date-bound deployments**: Container images are tied to specific deployment dates, making incident
+  investigation and rollback more intuitive
 - **No artificial versioning**: We don't manufacture semantic version increments; the calendar is the source of truth
-- **Simplifies CI/CD**: Release automation can key off git tags without managing version files or complex version-bump logic
+- **Simplifies CI/CD**: Release automation can key off git tags without managing version files or
+  complex version-bump logic
 
 ## Code Review
 

--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ nano compose/.env   # set ANTHROPIC_API_KEY, verify AGAMEMNON_URL
 ## Host requirements
 
 **Claude-only fleet (Phase 3):**
+
 - Memory: 12 GB minimum (5 Claude agents × 4G limit; practical min ~2.5 GB with reservations)
 - CPU: 2 cores
 - Disk: 5 GB for images
 
 **Full heterogeneous mesh (Phase 4):**
-- Memory: **50 GB hard limit** (8 AI agents × 4G + 1 worker × 1G); **practical minimum 8 GB** with memory reservations
+
+- Memory: **50 GB hard limit** (8 AI agents × 4G + 1 worker × 1G);
+  **practical minimum 8 GB** with memory reservations
 - CPU: 8+ cores recommended
 - Disk: 15 GB for images
 
@@ -140,8 +143,8 @@ echo -n "sk-proj-..."      > compose/secrets/openai_api_key
 chmod 600 compose/secrets/*
 ```
 
-Each container's `entrypoint.sh` reads `/run/secrets/anthropic_api_key` (or
-`openai_api_key`) and exports the value into the environment before handing off
+Each container's `entrypoint.sh` reads `/run/secrets/anthropic_api_key`
+(or `openai_api_key`) and exports the value into the environment before handing off
 to the agent. Leave `ANTHROPIC_API_KEY` and `OPENAI_API_KEY` blank in `.env`.
 
 The `compose/secrets/` directory is gitignored — only the `.gitkeep` placeholder
@@ -189,8 +192,10 @@ file boundaries. Override files that redefine `security_opt`, `cap_drop`, or `re
 without repeating all keys will silently drop your security settings.
 
 **Always verify the final config before deploying:**
+
 ```bash
-docker compose -f docker-compose.mesh.yml -f docker-compose.override.yml config | grep -A 2 'security_opt\|cap_drop\|read_only'
+docker compose -f docker-compose.mesh.yml -f docker-compose.override.yml config \
+  | grep -A 2 'security_opt\|cap_drop\|read_only'
 ```
 
 ### Logging configuration

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,8 @@
 
 ## Supported Images
 
-AchaeanFleet builds container images, not versioned software releases. The following image series receive security patches:
+AchaeanFleet builds container images, not versioned software releases. The following image series
+receive security patches:
 
 | Image Series                   | Supported |
 |--------------------------------|-----------|
@@ -10,7 +11,8 @@ AchaeanFleet builds container images, not versioned software releases. The follo
 | `achaean-*:<sha256-digest>`    | Yes (pinned digest builds) |
 | `achaean-*:<old-tag>`          | No — rebuild from `latest` |
 
-**Policy:** Only `latest` and pinned SHA256 digest builds are supported. There are no versioned release branches; rebuild from the current `main` to get security fixes.
+**Policy:** Only `latest` and pinned SHA256 digest builds are supported. There are no versioned
+release branches; rebuild from the current `main` to get security fixes.
 
 ## Reporting Security Vulnerabilities
 
@@ -26,7 +28,8 @@ Use GitHub's private vulnerability reporting:
 
 **[Report a vulnerability](https://github.com/mvillmow/AchaeanFleet/security/advisories/new)**
 
-**⚠️ Admin Setup Required:** Private vulnerability reporting must be enabled by a repo admin. If the link above returns a 404 or permission error, a maintainer needs to enable it first:
+**⚠️ Admin Setup Required:** Private vulnerability reporting must be enabled by a repo admin. If the
+link above returns a 404 or permission error, a maintainer needs to enable it first:
 
 1. Go to the repository's **Settings → Code security and analysis**
 2. Under **Private vulnerability reporting**, click **Enable**
@@ -34,7 +37,8 @@ Use GitHub's private vulnerability reporting:
 
 Until this is enabled, reporters should use the email fallback below.
 
-This is the preferred channel — it keeps the report private, lets us draft a coordinated advisory, and integrates with GitHub's Security tab automatically.
+This is the preferred channel — it keeps the report private, lets us draft a coordinated advisory,
+and integrates with GitHub's Security tab automatically.
 
 ### Email (Fallback)
 
@@ -121,27 +125,34 @@ When you report a vulnerability:
 ### In Scope
 
 **Credential exposure**
-- API keys, tokens, or secrets embedded in Dockerfiles, Compose files, or CI config (`ENV`, `ARG`, `--build-arg`, `.env` files checked in)
-- Home directory mounts (`- /home/...:/home/...`) that expose host credentials or SSH keys to containers
+
+- API keys, tokens, or secrets embedded in Dockerfiles, Compose files, or CI config
+  (`ENV`, `ARG`, `--build-arg`, `.env` files checked in)
+- Home directory mounts (`- /home/...:/home/...`) that expose host credentials or SSH keys to
+  containers
 
 **Privilege escalation**
+
 - Missing `USER` directive — containers running as root by default
 - `NOPASSWD` sudo grants inside images
 - Dangerous Linux capability grants (`--cap-add`, `SYS_ADMIN`, etc.)
 - Writable volume mounts into sensitive host paths
 
 **Config injection**
+
 - Insecure Docker Compose overrides that allow environment variable injection
 - Build arguments that propagate secrets into image layers
 - Writable socket or socket-proxy mounts without authentication
 
 **Supply chain risks**
+
 - Base image CVEs: OS package vulnerabilities introduced via `apt`/`apk` in `bases/` or `vessels/`
 - npm transitive dependency CVEs in Node-based vessels
 - `curl | bash` or `wget | sh` install patterns without checksum verification
 - Mutable image tags (`:latest` used as `FROM` without pinned digest in production)
 
 **Other**
+
 - Dockerfiles (base images and vessel images)
 - Docker Compose files (`compose/`)
 - Dagger CI pipeline scripts (`dagger/`)
@@ -157,7 +168,9 @@ When you report a vulnerability:
 
 ## Automated Detection
 
-AchaeanFleet CI runs [Trivy](https://github.com/aquasecurity/trivy-action) on all images with `severity: HIGH,CRITICAL`. CVEs already detected by Trivy in CI are tracked as issues; you do not need to report these separately unless you have additional exploitation context or a bypass.
+AchaeanFleet CI runs [Trivy](https://github.com/aquasecurity/trivy-action) on all images with
+`severity: HIGH,CRITICAL`. CVEs already detected by Trivy in CI are tracked as issues; you do not
+need to report these separately unless you have additional exploitation context or a bypass.
 
 ## Security Best Practices
 
@@ -173,16 +186,24 @@ When contributing to AchaeanFleet:
 
 ## CVE Suppression Policy (.trivyignore)
 
-The CI workflow uses `ignore-unfixed: true` in `aquasecurity/trivy-action`, which automatically skips CVEs that have no upstream fix. `.trivyignore` is reserved for the remaining edge cases: CVEs where a fix exists upstream but cannot yet be applied in this image, or where the vulnerable code path is provably unreachable.
+The CI workflow uses `ignore-unfixed: true` in `aquasecurity/trivy-action`, which automatically
+skips CVEs that have no upstream fix. `.trivyignore` is reserved for the remaining edge cases: CVEs
+where a fix exists upstream but cannot yet be applied in this image, or where the vulnerable code
+path is provably unreachable.
 
 ### When suppression is appropriate
 
 A CVE may be added to `.trivyignore` only after confirming **all** of the following:
 
-1. `ignore-unfixed: true` in the workflow does not already suppress it — if it does, no `.trivyignore` entry is needed.
-2. The fix is not available in the current base image's OS distribution (verify against the Debian Security Tracker, Alpine secdb, or the relevant upstream advisory).
-3. Bumping the base image digest and running `apt-get upgrade -y` in a local test build does **not** resolve the finding.
-4. Either: (a) no attacker-controlled input path to the vulnerable code exists in this repo's runtime context, or (b) the upstream package maintainer has acknowledged the issue but has not yet released a patched version.
+1. `ignore-unfixed: true` in the workflow does not already suppress it — if it does, no
+   `.trivyignore` entry is needed.
+1. The fix is not available in the current base image's OS distribution (verify against the Debian
+   Security Tracker, Alpine secdb, or the relevant upstream advisory).
+1. Bumping the base image digest and running `apt-get upgrade -y` in a local test build does **not**
+   resolve the finding.
+1. Either: (a) no attacker-controlled input path to the vulnerable code exists in this repo's runtime
+   context, or (b) the upstream package maintainer has acknowledged the issue but has not yet
+   released a patched version.
 
 Suppression is a last resort. Prefer bumping the base image digest first.
 
@@ -211,9 +232,12 @@ All six fields are required. Entries missing any field will be rejected in PR re
 
 ### Expiry and maintenance
 
-- On or before the `Expires` date, the entry must be re-reviewed: either removed (if a fix is now available in the base image) or renewed with an updated `Expires` date via a new PR.
-- When bumping base image digests, re-scan locally and remove any `.trivyignore` entries that are resolved by the new digest.
-- Entries past their expiry date are treated as a policy violation — open a PR to remove or renew them before they block CI.
+- On or before the `Expires` date, the entry must be re-reviewed: either removed (if a fix is now
+  available in the base image) or renewed with an updated `Expires` date via a new PR.
+- When bumping base image digests, re-scan locally and remove any `.trivyignore` entries that are
+  resolved by the new digest.
+- Entries past their expiry date are treated as a policy violation — open a PR to remove or renew
+  them before they block CI.
 
 ### What `.trivyignore` is NOT for
 

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,6 +1,7 @@
 # Versioning Strategy
 
-AchaeanFleet uses a three-tier image tagging strategy to support both mutable continuous deployments and immutable release pinning.
+AchaeanFleet uses a three-tier image tagging strategy to support both mutable continuous deployments
+and immutable release pinning.
 
 ## Tag Types
 
@@ -9,10 +10,13 @@ AchaeanFleet uses a three-tier image tagging strategy to support both mutable co
 Every push to the `main` branch produces three tags per image:
 
 - **`:latest`** — Mutable tag pointing to the most recent main build. Use for development and fast-moving deployments.
-- **`:git-<7sha>`** — Immutable tag with the 7-character git commit SHA. Recommended for pinning to a specific commit.
-- **`:YYYY-MM-DD-<7sha>`** — Immutable date-keyed tag with SHA suffix. Useful for audit trails and collision-safe rollback.
+- **`:git-<7sha>`** — Immutable tag with the 7-character git commit SHA. Recommended for pinning to
+  a specific commit.
+- **`:YYYY-MM-DD-<7sha>`** — Immutable date-keyed tag with SHA suffix. Useful for audit trails and
+  collision-safe rollback.
 
 Example (commit abc1234 pushed 2026-04-23):
+
 ```
 ghcr.io/homericintelligence/achaean-claude:latest
 ghcr.io/homericintelligence/achaean-claude:git-abc1234
@@ -21,12 +25,14 @@ ghcr.io/homericintelligence/achaean-claude:2026-04-23-abc1234
 
 ### Release Tags (Version Tag Pushes)
 
-When you push a git tag matching `vMAJOR.MINOR.PATCH` (e.g., `v1.2.3`), the CI workflow additionally produces:
+When you push a git tag matching `vMAJOR.MINOR.PATCH` (e.g., `v1.2.3`), the CI workflow additionally
+produces:
 
 - **`:vMAJOR.MINOR.PATCH`** — Full semver tag, e.g., `:v1.2.3`
 - **`:MAJOR.MINOR`** — Minor-level alias for automatic minor-version upgrades, e.g., `:1.2`
 
 Example (pushing tag `v1.2.3`):
+
 ```
 ghcr.io/homericintelligence/achaean-claude:v1.2.3
 ghcr.io/homericintelligence/achaean-claude:1.2
@@ -37,13 +43,17 @@ ghcr.io/homericintelligence/achaean-claude:latest  # updated
 
 ## Creating a Release
 
-1. **Bump the version** in your local repository by deciding on the next semantic version (e.g., `1.2.0` → `1.2.1`).
-2. **Create and push the release tag**:
+1. **Bump the version** in your local repository by deciding on the next semantic version
+   (e.g., `1.2.0` → `1.2.1`).
+1. **Create and push the release tag**:
+
    ```bash
    git tag v1.2.1
    git push origin v1.2.1
    ```
-3. **Validate the release**: The `release.yml` workflow will trigger automatically, validate the tag format, and push images with all appropriate tags to GHCR.
+
+1. **Validate the release**: The `release.yml` workflow will trigger automatically, validate the tag
+   format, and push images with all appropriate tags to GHCR.
 
 Tags must match the pattern `v[0-9]+.[0-9]+.[0-9]+` (e.g., `v1.0.0`, `v1.2.3`). The workflow will reject malformed tags.
 
@@ -69,13 +79,16 @@ CLAUDE_IMAGE=achaean-claude:1.2
 ```
 
 Always specify the full registry path for remote deployments:
+
 ```bash
 CLAUDE_IMAGE=ghcr.io/homericintelligence/achaean-claude:git-abc1234
 ```
 
 ## CI Workflows
 
-- **`ci.yml`** (on push to main): Builds and validates all images; pushes `:latest`, `:git-<sha>`, and `:YYYY-MM-DD-<sha>` tags.
-- **`release.yml`** (on version tag push): Validates semver format; builds and pushes `:vMAJOR.MINOR.PATCH` and `:MAJOR.MINOR` tags.
+- **`ci.yml`** (on push to main): Builds and validates all images; pushes `:latest`, `:git-<sha>`,
+  and `:YYYY-MM-DD-<sha>` tags.
+- **`release.yml`** (on version tag push): Validates semver format; builds and pushes
+  `:vMAJOR.MINOR.PATCH` and `:MAJOR.MINOR` tags.
 
 Both workflows inherit all commit-based tags from the triggering commit.

--- a/VERSIONS.md
+++ b/VERSIONS.md
@@ -11,23 +11,23 @@ Versions verified: **2026-04-10**
 
 | Vessel | Package / Binary | Pinned version | Registry / Releases |
 |--------|-----------------|----------------|---------------------|
-| `claude` | `@anthropic-ai/claude-code` | `2.1.101` | https://www.npmjs.com/package/@anthropic-ai/claude-code |
-| `claude` | `gh` (GitHub CLI) | `v2.89.0` | https://github.com/cli/cli/releases |
-| `aider` | `aider-chat` | `0.82.3` | https://pypi.org/project/aider-chat/ |
-| `ampcode` | `@sourcegraph/amp` | `0.0.1775866026-gd3abf3` | https://www.npmjs.com/package/@sourcegraph/amp |
-| `cline` | `cline` | `2.14.0` | https://www.npmjs.com/package/cline |
-| `codebuff` | `codebuff` | `1.0.638` | https://www.npmjs.com/package/codebuff |
-| `codex` | `@openai/codex` | `0.120.0` | https://www.npmjs.com/package/@openai/codex |
-| `goose` | Goose CLI binary | `v1.30.0` | https://github.com/block/goose/releases |
-| `opencode` | OpenCode binary | `v1.4.3` | https://github.com/sst/opencode/releases |
-| `worker` | `yq` binary | `v4.52.5` | https://github.com/mikefarah/yq/releases |
+| `claude` | `@anthropic-ai/claude-code` | `2.1.101` | <https://www.npmjs.com/package/@anthropic-ai/claude-code> |
+| `claude` | `gh` (GitHub CLI) | `v2.89.0` | <https://github.com/cli/cli/releases> |
+| `aider` | `aider-chat` | `0.82.3` | <https://pypi.org/project/aider-chat/> |
+| `ampcode` | `@sourcegraph/amp` | `0.0.1775866026-gd3abf3` | <https://www.npmjs.com/package/@sourcegraph/amp> |
+| `cline` | `cline` | `2.14.0` | <https://www.npmjs.com/package/cline> |
+| `codebuff` | `codebuff` | `1.0.638` | <https://www.npmjs.com/package/codebuff> |
+| `codex` | `@openai/codex` | `0.120.0` | <https://www.npmjs.com/package/@openai/codex> |
+| `goose` | Goose CLI binary | `v1.30.0` | <https://github.com/block/goose/releases> |
+| `opencode` | OpenCode binary | `v1.4.3` | <https://github.com/sst/opencode/releases> |
+| `worker` | `yq` binary | `v4.52.5` | <https://github.com/mikefarah/yq/releases> |
 
 ## Base image tool versions
 
 | Base image | Package | Pinned version | Registry |
 |-----------|---------|----------------|----------|
-| `minimal`, `python` | `yarn` | `1.22.22` | https://www.npmjs.com/package/yarn |
-| `python` | `pip` | `26.0.1` | https://pypi.org/project/pip/ |
+| `minimal`, `python` | `yarn` | `1.22.22` | <https://www.npmjs.com/package/yarn> |
+| `python` | `pip` | `26.0.1` | <https://pypi.org/project/pip/> |
 
 ---
 

--- a/docs/adr/007-tls-mesh-communications.md
+++ b/docs/adr/007-tls-mesh-communications.md
@@ -2,7 +2,8 @@
 
 **Status:** Accepted
 **Date:** 2026-04-10
-**Issue:** [#26 — Security: Agent containers use NATS and Agamemnon over unencrypted HTTP](https://github.com/HomericIntelligence/AchaeanFleet/issues/26)
+**Issue:** [#26 — Security: Agent containers use NATS and Agamemnon over unencrypted HTTP](
+https://github.com/HomericIntelligence/AchaeanFleet/issues/26)
 **OWASP:** A02:2021 — Cryptographic Failures
 
 ---
@@ -36,6 +37,7 @@ Key decisions:
 ### 1. Caddy over Traefik/nginx
 
 Caddy was chosen because:
+
 - Zero-config TLS: `tls cert key` in the Caddyfile is sufficient
 - Self-signed CA workflow is first-class (no ACME required)
 - Built-in health endpoint on `:2019` for Docker health checks
@@ -113,6 +115,7 @@ Docker containers without a sidecar, making it unsuitable as a universal solutio
 
 Full mTLS (each agent presents a client cert to Caddy) was considered as a Phase 5/6
 hardening step. Not implemented now because:
+
 - Agent processes (Claude Code, Aider, etc.) don't currently have a mechanism to
   present client certs
 - Server-side TLS (Caddy validates the connection; agents validate Caddy's cert)
@@ -132,6 +135,7 @@ alongside the mesh.
 
 ## Related
 
-- [ADR-006](https://github.com/HomericIntelligence/Odysseus/blob/main/docs/adr/006-decouple-from-ai-maestro.md) — ai-maestro decoupling (renamed `AGAMEMNON_URL`)
+- [ADR-006](https://github.com/HomericIntelligence/Odysseus/blob/main/docs/adr/006-decouple-from-ai-maestro.md) —
+  ai-maestro decoupling (renamed `AGAMEMNON_URL`)
 - [`tls/README.md`](../../tls/README.md) — operational guide (cert generation, rotation, verification)
 - [SECURITY.md](../../SECURITY.md) — security policy and reporting

--- a/docs/image-sizes.md
+++ b/docs/image-sizes.md
@@ -64,7 +64,7 @@ docker build -f bases/Dockerfile.minimal -t achaean-base-minimal:test .
 docker images --format "{{.Repository}}\t{{.Tag}}\t{{.Size}}" | grep achaean-base-minimal
 ```
 
-### Base Images
+### Base Image Measurements
 
 | Date | Image | Size | Build Context | Notes |
 |------|-------|------|---------------|-------|
@@ -88,10 +88,14 @@ docker images --format "{{.Repository}}\t{{.Tag}}\t{{.Size}}" | grep achaean-bas
 
 ## Notes
 
-- Actual sizes vary by Docker layer cache state and base image updates (e.g., Debian security patches, Node.js/Python point releases).
+- Actual sizes vary by Docker layer cache state and base image updates
+  (e.g., Debian security patches, Node.js/Python point releases).
 - To record a new measurement:
-  1. Build the image locally: `docker build -f <dockerfile> -t achaean-<name>:test .` (or `npx ts-node dagger/pipeline.ts build`)
-  2. Get the size: `docker images achaean-<name> --format "{{.Size}}"`
-  3. Add a dated row to the tables above with the actual size, build date, and any relevant context
-- Size checks are not currently automated in CI. Consider adding a size-gate job (e.g., `dagger/pipeline.ts` size assertion step) to enforce post-refactor targets.
+  1. Build the image locally:
+     `docker build -f <dockerfile> -t achaean-<name>:test .`
+     (or `npx ts-node dagger/pipeline.ts build`)
+  1. Get the size: `docker images achaean-<name> --format "{{.Size}}"`
+  1. Add a dated row to the tables above with the actual size, build date, and any relevant context
+- Size checks are not currently automated in CI. Consider adding a size-gate job
+  (e.g., `dagger/pipeline.ts` size assertion step) to enforce post-refactor targets.
 - Layer analysis: use `docker history <image>` to identify layers contributing most to final size.

--- a/docs/image-tagging.md
+++ b/docs/image-tagging.md
@@ -12,7 +12,8 @@ Every push to `main` produces **three tags per image**, built once and published
 
 ### Why not bare `:YYYY-MM-DD`?
 
-A bare date tag is overwritten on every push to `main` that occurs on the same calendar day. The SHA suffix (`-<7sha>`) disambiguates multiple same-day pushes and makes the tag immutable once created.
+A bare date tag is overwritten on every push to `main` that occurs on the same calendar day. The SHA
+suffix (`-<7sha>`) disambiguates multiple same-day pushes and makes the tag immutable once created.
 
 ## Examples
 
@@ -34,6 +35,7 @@ Two pushes on the same day produce distinct date tags:
 ## Rollback procedure
 
 **By commit:**
+
 ```bash
 # Edit compose/.env or docker-compose override:
 CLAUDE_IMAGE=ghcr.io/homericintelligence/achaean-claude:git-abc1234
@@ -41,12 +43,14 @@ docker compose up -d
 ```
 
 **By date:**
+
 ```bash
 CLAUDE_IMAGE=ghcr.io/homericintelligence/achaean-claude:2026-04-23-abc1234
 docker compose up -d
 ```
 
 **List available tags:**
+
 ```bash
 gh api /orgs/homericintelligence/packages/container/achaean-claude/versions \
   --jq '.[].metadata.container.tags[]'
@@ -56,9 +60,11 @@ gh api /orgs/homericintelligence/packages/container/achaean-claude/versions \
 
 The `push-to-registry` job in `.github/workflows/ci.yml`:
 
-1. Runs a **Compute build metadata** step that safely captures `GITHUB_SHA` via an `env:` block (avoiding shell injection) and writes `short_sha` and `date_tag` to `$GITHUB_OUTPUT`.
-2. Passes `SHORT_SHA` and `DATE_TAG` as environment variables to the Dagger pipeline.
-3. The Dagger pipeline (`dagger/pipeline.ts`) reads those env vars and publishes all three tags in a loop — images are built **once** and pushed with multiple tags.
+1. Runs a **Compute build metadata** step that safely captures `GITHUB_SHA` via an `env:` block
+   (avoiding shell injection) and writes `short_sha` and `date_tag` to `$GITHUB_OUTPUT`.
+1. Passes `SHORT_SHA` and `DATE_TAG` as environment variables to the Dagger pipeline.
+1. The Dagger pipeline (`dagger/pipeline.ts`) reads those env vars and publishes all three tags in a
+   loop — images are built **once** and pushed with multiple tags.
 
 Local builds (no env vars set) fall back to `:latest` and `:local-<local>` tags so development workflows are unaffected.
 
@@ -66,26 +72,32 @@ Local builds (no env vars set) fall back to `:latest` and `:local-<local>` tags 
 
 ### Tag mutability
 
-- **`:latest`** — Mutable. Overwritten on every push to `main`. Do not rely on it for reproducible deployments.
-- **`:git-<sha>` and `:YYYY-MM-DD-<sha>`** — Immutable once created. These tags accumulate indefinitely in GHCR, as new commits and days produce new tags.
+- **`:latest`** — Mutable. Overwritten on every push to `main`. Do not rely on it for reproducible
+  deployments.
+- **`:git-<sha>` and `:YYYY-MM-DD-<sha>`** — Immutable once created. These tags accumulate
+  indefinitely in GHCR, as new commits and days produce new tags.
 
 ### Cleanup policy
 
 With three tags per push, untagged manifests and old tags can accumulate in GHCR over time. We recommend:
 
-1. **Untagged manifests**: Delete all manifests older than 90 days. These accumulate when tags are pruned but the underlying layers remain.
-2. **Tagged historical images**: Set a retention window (e.g., keep all tags from the last 180 days, prune older ones).
-3. **Automation**: Enable "Delete untagged versions" in the GHCR package settings for each agent image.
+1. **Untagged manifests**: Delete all manifests older than 90 days. These accumulate when tags are
+   pruned but the underlying layers remain.
+1. **Tagged historical images**: Set a retention window (e.g., keep all tags from the last 180 days,
+   prune older ones).
+1. **Automation**: Enable "Delete untagged versions" in the GHCR package settings for each agent image.
 
 ### Listing and managing tags
 
 **List all tags for an image:**
+
 ```bash
 gh api /orgs/HomericIntelligence/packages/container/achaean-claude/versions \
   --jq '.[] | .metadata.container.tags[]'
 ```
 
 **Find old tags (example: tags older than 90 days):**
+
 ```bash
 gh api /orgs/HomericIntelligence/packages/container/achaean-claude/versions \
   --jq '.[] | select(.created_at < now - 7776000) | {id, created_at, tags: .metadata.container.tags[]}'
@@ -95,8 +107,10 @@ gh api /orgs/HomericIntelligence/packages/container/achaean-claude/versions \
 
 GHCR does not have built-in automatic pruning. To reduce accumulation:
 
-1. In the GitHub UI, navigate to **Settings → Packages and registries → Package settings** for each agent image.
-2. Enable **"Delete untagged versions"** to remove orphaned manifests automatically.
-3. Set a retention policy for tagged versions manually or via scheduled GitHub Actions, if needed.
+1. In the GitHub UI, navigate to **Settings → Packages and registries → Package settings** for each
+   agent image.
+1. Enable **"Delete untagged versions"** to remove orphaned manifests automatically.
+1. Set a retention policy for tagged versions manually or via scheduled GitHub Actions, if needed.
 
-For production deployments, pin to immutable tags (`:git-<sha>` or `:YYYY-MM-DD-<sha>`) and monitor the package registry periodically for cleanup.
+For production deployments, pin to immutable tags (`:git-<sha>` or `:YYYY-MM-DD-<sha>`) and monitor
+the package registry periodically for cleanup.

--- a/docs/network-topology.md
+++ b/docs/network-topology.md
@@ -1,6 +1,7 @@
 # Network Topology
 
-AchaeanFleet uses two named Docker bridge networks to limit the blast radius of a compromised agent container (defense-in-depth, zero-trust principles).
+AchaeanFleet uses two named Docker bridge networks to limit the blast radius of a compromised agent
+container (defense-in-depth, zero-trust principles).
 
 ## Networks
 
@@ -52,19 +53,30 @@ AchaeanFleet uses two named Docker bridge networks to limit the blast radius of 
 ## Design decisions
 
 **Why two networks instead of one?**
-Previously all containers shared a single flat `homeric-mesh` network. Any compromised agent could reach every other agent on any port. Splitting into frontend/backend limits lateral movement: a compromised AI agent on `agamemnon-frontend` cannot directly probe the `agent-backend` subnet.
+Previously all containers shared a single flat `homeric-mesh` network. Any compromised agent could
+reach every other agent on any port. Splitting into frontend/backend limits lateral movement: a
+compromised AI agent on `agamemnon-frontend` cannot directly probe the `agent-backend` subnet.
 
 **Why is `agent-backend` currently sparse?**
-No current agent-to-agent protocol requires direct container-to-container communication. The network exists as infrastructure ready for future use (e.g., a pipeline where one agent hands off work to another). `hi-worker-1` is the natural bridge because it is the orchestration primitive with no AI tool dependency.
+No current agent-to-agent protocol requires direct container-to-container communication. The network
+exists as infrastructure ready for future use (e.g., a pipeline where one agent hands off work to
+another). `hi-worker-1` is the natural bridge because it is the orchestration primitive with no AI
+tool dependency.
 
 **Why are network names hard-coded instead of env-var-driven?**
-The two networks have architectural meaning — `agamemnon-frontend` always connects to Agamemnon, `agent-backend` always carries lateral traffic. Allowing arbitrary runtime renaming would make the topology ambiguous. The former `MESH_NETWORK` env var has been removed.
+The two networks have architectural meaning — `agamemnon-frontend` always connects to Agamemnon,
+`agent-backend` always carries lateral traffic. Allowing arbitrary runtime renaming would make the
+topology ambiguous. The former `MESH_NETWORK` env var has been removed.
 
 **How does ProjectAgamemnon reach agents?**
-ProjectAgamemnon runs on the host (not in a container). It connects to agent HTTP endpoints via the Docker bridge gateway IP `172.20.0.1`, which is the host-side address of the `agamemnon-frontend` bridge. No Compose-internal DNS is needed for host → container communication.
+ProjectAgamemnon runs on the host (not in a container). It connects to agent HTTP endpoints via the
+Docker bridge gateway IP `172.20.0.1`, which is the host-side address of the `agamemnon-frontend`
+bridge. No Compose-internal DNS is needed for host → container communication.
 
 **How do agents resolve each other?**
-Agents on the same network (`agamemnon-frontend`) resolve each other by hostname via Docker's embedded DNS. For example, `hi-aindrea` can reach `hi-baird` at `http://hi-baird:23001`. This is standard Docker Compose DNS — no IP injection needed (that workaround is Podman-specific).
+Agents on the same network (`agamemnon-frontend`) resolve each other by hostname via Docker's
+embedded DNS. For example, `hi-aindrea` can reach `hi-baird` at `http://hi-baird:23001`. This is
+standard Docker Compose DNS — no IP injection needed (that workaround is Podman-specific).
 
 ## Adding a new agent
 

--- a/nomad/PATTERNS.md
+++ b/nomad/PATTERNS.md
@@ -111,6 +111,7 @@ EOH
 ```
 
 **Key rules:**
+
 - **Never use inline env vars** for secrets (`env { ANTHROPIC_API_KEY = "sk-..." }`)
 - **Never store secrets in HCL** or `.nomadvar` files
 - **Always use `template` with Vault backend** for dynamic secret injection
@@ -137,6 +138,7 @@ When you need to override a Docker image's `ENTRYPOINT` or `CMD` in Nomad, use t
 debugging, or running alternative entry points.
 
 **Key fields:**
+
 - `entrypoint` — array replacing the image's `ENTRYPOINT` instruction
 - `args` — array replacing the image's `CMD` instruction
 - `command` — NOT the same as `cmd`; use `entrypoint` + `args` instead

--- a/tls/README.md
+++ b/tls/README.md
@@ -119,11 +119,13 @@ When Hermes/Keystone are wired into the mesh, NATS must use TLS from day one.
 See `tls/nats/nats-tls.conf` for the server config template.
 
 Agents connect with:
+
 ```
 NATS_URL=tls://nats:4222
 ```
 
 Validate with:
+
 ```bash
 nats pub -s "tls://localhost:4222" \
   --tlscacert tls/certs/ca.crt \

--- a/vessels/goose/README.md
+++ b/vessels/goose/README.md
@@ -4,7 +4,8 @@ Goose is a Block AI agent that runs as part of the AchaeanFleet mesh.
 
 ## Version Upgrade Procedure
 
-This vessel pins a specific Goose release version and its cryptographic checksums for both AMD64 and ARM64 architectures.
+This vessel pins a specific Goose release version and its cryptographic checksums for both AMD64
+and ARM64 architectures.
 
 ### Current Version
 
@@ -12,18 +13,19 @@ See `Dockerfile` for the current `GOOSE_VERSION`, `GOOSE_AMD64_SHA256`, and `GOO
 
 ### Where to Find Release Checksums
 
-Goose releases are published at: https://github.com/block/goose/releases
+Goose releases are published at: <https://github.com/block/goose/releases>
 
 Each release includes:
+
 - `goose-x86_64-unknown-linux-gnu.tar.gz` (AMD64)
 - `goose-aarch64-unknown-linux-gnu.tar.gz` (ARM64)
 - SHA256 checksums in the release notes or downloadable checksum files
 
 ### Updating to a New Version
 
-1. Visit https://github.com/block/goose/releases and select the target version
-2. Copy the SHA256 checksums for both AMD64 and ARM64 archives
-3. Update `Dockerfile`:
+1. Visit <https://github.com/block/goose/releases> and select the target version
+1. Copy the SHA256 checksums for both AMD64 and ARM64 archives
+1. Update `Dockerfile`:
    - Change `GOOSE_VERSION=X.Y.Z` to the new version
    - Update `GOOSE_AMD64_SHA256=<new-amd64-hash>`
    - Update `GOOSE_ARM64_SHA256=<new-arm64-hash>`


### PR DESCRIPTION
## Summary

- Reformats markdown documentation files to satisfy markdownlint rules (line length, list spacing, heading levels, code fence language specifiers)
- Files updated: CLAUDE.md, CONTRIBUTING.md, README.md, SECURITY.md, VERSIONING.md, VERSIONS.md, several docs/*.md, nomad/PATTERNS.md, tls/README.md, vessels/goose/README.md

Supersedes #575 (signed commits, rebased on current main, no CI action version downgrades).

## Test plan

- [ ] CI passes (all 8 required checks)
- [ ] markdownlint job passes on the reformatted files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>