### PR TITLE
fix(compliance): update LICENSE copyright year to 2025-2026

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2025, HomericIntelligence Contributors
+Copyright (c) 2025-2026, HomericIntelligence Contributors
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:


### PR DESCRIPTION
Closes #588, #605

## Summary

- Updates LICENSE copyright year from `2025` to `2025-2026`
- Current year is 2026; two audit findings (#588 §2 and #605 §15) both identified this stale year
- Bundled into a single PR since both issues fix the same line in the same file

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)