### PR TITLE
docs(lint): fix misleading hadolint suppression rationale comments

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -12,11 +12,14 @@ ignore:
 
   # DL3015: Avoid --no-install-recommends.
   # Base images intentionally install recommended packages for a full
-  # developer/agent environment.
+  # developer/agent environment. Usage is intentionally inconsistent
+  # across base images — policy is to allow recommended packages globally.
   - DL3015
 
   # DL3016: npm packages not pinned to a specific version.
-  # Vessel images install CLI tools at latest by design.
+  # All vessel Dockerfiles pin npm packages to exact versions; however,
+  # hadolint cannot always statically verify pinning via ARG substitution,
+  # so the rule is suppressed globally to avoid false positives.
   - DL3016
 
   # DL3013: pip packages not pinned to a specific version.


### PR DESCRIPTION
Closes #611, #613

## Summary

- **#613**: Corrects the DL3016 rationale in `.hadolint.yaml` — the previous comment said "Vessel images install CLI tools at latest by design" which is factually wrong: all vessel Dockerfiles pin npm packages to exact versions (e.g., `@anthropic-ai/claude-code@2.1.101`). Updated comment explains the real reason (hadolint cannot resolve ARG substitutions).
- **#611**: Clarifies the DL3015 rationale to document that the `--no-install-recommends` inconsistency across base images is intentional, and that the global suppression policy covers all base images.
- Both issues target `.hadolint.yaml` comments only — no functional behavior changes.

## Test plan

- [ ] CI passes
- [ ] `hadolint` continues to pass on all Dockerfiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)