### PR TITLE
docs(bases): correct misleading header comment in common-setup.sh

### DIFF
--- a/bases/common-setup.sh
+++ b/bases/common-setup.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
-# bases/common-setup.sh — Shared setup steps for all AchaeanFleet base images.
+# bases/common-setup.sh — Shared setup steps for AchaeanFleet base images.
 #
-# Called during Docker build (as root) to:
+# NOTE: This script is not currently called by any Dockerfile. It exists as
+# a reference implementation of the common setup steps. To use it, copy it
+# into a Dockerfile build context and invoke it as shown below.
+#
+# Intended to be run during Docker build (as root) to:
 #   1. Configure tmux for the 'agent' user
 #   2. Install Oh My Zsh for the 'agent' user
 #   3. Create /workspace and /app directories with correct ownership


### PR DESCRIPTION
Closes #608

## Summary

- `bases/common-setup.sh` had a header claiming it is "Called during Docker build" but no Dockerfile in the repo references this script
- Updated the header to clarify that the script is currently unused and exists as a reference implementation
- Added a `NOTE:` callout so future contributors understand the script's actual status
- No functional changes — comment fix only

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)