### PR TITLE
docs: document hephaestus/ Python module in CLAUDE.md and README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,20 @@ vessels/        9 agent vessel Dockerfiles (FROM a base + AI tool)
 compose/        Docker Compose files (claude-only and full mesh)
 nomad/          Nomad job specs (Phase 6)
 dagger/         Dagger pipeline for CI/CD (Phase 5)
+hephaestus/     Python utilities for image tagging and digest verification
 .github/        GitHub Actions CI
 ```
+
+## hephaestus/ Python module
+
+The `hephaestus/` directory contains Python utilities used by CI and tests:
+
+- **`tags.py`** — Image tag generation (`:latest`, `:git-<sha>`, `:YYYY-MM-DD-<sha>`)
+- **`digest.py`** — Docker image digest capture and validation before registry push
+- **`tag_verify.py`** — Post-push GHCR tag verification helpers
+
+These modules are imported by `tests/` and used in the CI push-to-registry job for
+auditor traceability between built artifacts and pushed registry images.
 
 ## Building images locally
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,18 @@ Both checks run automatically in CI on every PR that touches `bases/**`, `vessel
 5. Add to the build matrix in `.github/workflows/ci.yml`
 6. Run `just build-vessel <name>` to verify
 
+## hephaestus/ Python utilities
+
+The `hephaestus/` directory provides Python utilities used by CI and the test suite:
+
+| Module | Purpose |
+|--------|---------|
+| `hephaestus/tags.py` | Image tag generation (`:latest`, `:git-<sha>`, `:YYYY-MM-DD-<sha>`) |
+| `hephaestus/digest.py` | Docker image digest capture and validation before registry push |
+| `hephaestus/tag_verify.py` | Post-push GHCR tag verification helpers |
+
+These modules are imported by `tests/` to verify that CI pushes the expected tags to GHCR.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for Dockerfile conventions, branch strategy, and the PR


### PR DESCRIPTION
Closes #615

## Summary

- Adds a `hephaestus/ Python module` section to `README.md` with a table describing each module's purpose (`tags.py`, `digest.py`, `tag_verify.py`)
- Adds a `hephaestus/` entry to the directory structure in `CLAUDE.md` plus a dedicated explanation section
- Resolves POLA finding: tagging utilities were invisible to AI agents and new contributors without a directory listing

## Test plan

- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)