### PR TITLE
chore(deps): add pixi package ecosystem to renovate.json

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,12 @@
       "matchManagers": ["github-actions"],
       "enabled": true,
       "groupName": "github actions"
+    },
+    {
+      "matchManagers": ["pep621"],
+      "matchFileNames": ["pixi.toml"],
+      "enabled": true,
+      "groupName": "pixi python dependencies"
     }
   ]
 }


### PR DESCRIPTION
Closes #616

## Summary

- Adds a `pep621` manager rule to `renovate.json` targeting `pixi.toml`
- Python dependencies declared in `pixi.toml` (e.g., pytest, pre-commit) previously had no Renovate coverage, leaving them to drift without automated PRs
- Uses the `pep621` manager which is Renovate's supported way to manage `pixi.toml` Python dependencies

## Test plan

- [ ] CI passes
- [ ] Renovate bot picks up the new rule on its next run

🤖 Generated with [Claude Code](https://claude.com/claude-code)