### PR TITLE
fix(bootstrap): validate .env for merge conflict markers; fix stale marker in .env.example

### DIFF
--- a/compose/.env.example
+++ b/compose/.env.example
@@ -203,7 +203,7 @@ WORKER_MEM_LIMIT=1G
 WORKER_MEM_RESERVATION=128M
 WORKER_CPU_LIMIT=1.0
 WORKER_CPU_RESERVATION=0.1
-=======
+
 # Logging
 # =============================================================================
 LOG_MAX_SIZE=10m

--- a/justfile
+++ b/justfile
@@ -91,6 +91,14 @@ bootstrap:
         echo "  compose/.env already exists — skipping copy"
     fi
 
+    # Warn if .env contains merge conflict markers
+    if grep -qE '^(<<<<<<<|=======|>>>>>>>)' compose/.env 2>/dev/null; then
+        echo ""
+        echo "  ERROR: compose/.env contains git merge conflict markers (=======, <<<<<<<, >>>>>>>)."
+        echo "  Resolve the conflicts before running 'just compose-up'."
+        exit 1
+    fi
+
     # Warn if any API key looks like a placeholder
     placeholder_keys=()
     if grep -qE '^ANTHROPIC_API_KEY=($|your_key_here|<.*>|PLACEHOLDER|changeme)' compose/.env 2>/dev/null; then


### PR DESCRIPTION
Closes #617

## Summary

- Adds a merge conflict marker check (`=======`, `<<<<<<<`, `>>>>>>>`) to the `bootstrap` recipe in `justfile`; the check exits with a clear error message if markers are found in `compose/.env`, preventing a silent broken environment
- Removes the stale `=======` conflict marker committed on line 206 of `compose/.env.example` (the root cause that prompted this finding)
- The check runs after `.env` is created from `.env.example` but before the placeholder-key warnings, so it surfaces the most critical problem first

## Test plan

- [ ] CI passes
- [ ] `just bootstrap` on a clean env proceeds normally
- [ ] `just bootstrap` with `=======` in `.env` prints an error and exits 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)