### PR TITLE
ci: add tsc --noEmit type-check step to validate-dagger job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,10 @@ jobs:
         working-directory: dagger
         run: npm audit --audit-level=high
 
+      - name: Type-check TypeScript pipeline
+        working-directory: dagger
+        run: npx tsc --noEmit
+
       - name: Audit Python dependencies (aider-chat)
         run: |
           pip install --quiet pip-audit aider-chat 2>/dev/null || true


### PR DESCRIPTION
Closes #612

## Summary

- Adds a `tsc --noEmit` step to the `validate-dagger` CI job after `npm audit`
- `dagger/pipeline.ts` previously had no TypeScript type checking in CI; only `npm audit` and build ran
- The three `@ts-ignore` comments in `pipeline.ts` will still suppress their specific lines, but any other type regressions will now be caught in CI
- Uses `npx tsc` to avoid a global TypeScript install — `tsconfig.json` already exists in `dagger/`

## Test plan

- [ ] CI passes (all three `@ts-ignore` lines pass type checking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)