### PR TITLE
fix(ci): Build All Agent Images failing on main

### DIFF
--- a/vessels/aider/Dockerfile
+++ b/vessels/aider/Dockerfile
@@ -1,9 +1,23 @@
 # AchaeanFleet Vessel: Aider
 #
-# Installs aider-chat on top of the Python base image.
-# Supports Python 3.9-3.12; this image uses 3.12.
+# aider-chat releases up to 0.86.x require Python ">=3.10,<3.13", but the
+# achaean-base-python image runs Python 3.14. To keep the shared base while
+# satisfying aider's interpreter constraint, we copy a self-contained
+# Python 3.12 from the official python:3.12-slim image into /opt/python3.12
+# and install aider-chat into a venv built with that interpreter.
+#
+# This avoids forking a separate base image just for aider and keeps the rest
+# of the agent setup (user, tmux, oh-my-zsh, entrypoint) inherited from the
+# shared base.
 
+# Global ARG must be declared before the first FROM so it can be referenced
+# by later FROM stages (Docker scopes ARGs declared between FROMs to that stage
+# only).
 ARG BASE_IMAGE=achaean-base-python:latest
+
+# Source stage — provides a complete Python 3.12 install we can copy whole.
+FROM python:3.12-slim@sha256:ec948fa5f90f4f8907e89f4800cfd2d2e91e391a4bce4a6afa77ba265bc3a2fe AS python312-source
+
 FROM ${BASE_IMAGE}
 
 LABEL org.opencontainers.image.title="achaean-aider"
@@ -20,11 +34,22 @@ LABEL git-sha=${GIT_SHA}
 
 USER root
 
+# Bring Python 3.12 in as a self-contained install at /opt/python3.12 so the
+# venv we build below has a real interpreter to point at, independent of the
+# base image's Python 3.14.
+COPY --from=python312-source /usr/local /opt/python3.12
+
 # Copy requirements.txt for reproducible dependency management
 COPY vessels/aider/requirements.txt /tmp/requirements.txt
 
-# Install aider-chat (version pinned for reproducibility — issue #2)
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+# Create an isolated venv with Python 3.12 and install aider-chat into it.
+# We expose `aider` on PATH via a symlink so existing AGENT_PROGRAM=aider
+# wiring continues to work without changes elsewhere.
+RUN /opt/python3.12/bin/python3.12 -m venv /opt/aider-venv \
+    && /opt/aider-venv/bin/pip install --no-cache-dir --upgrade pip \
+    && /opt/aider-venv/bin/pip install --no-cache-dir -r /tmp/requirements.txt \
+    && ln -sf /opt/aider-venv/bin/aider /usr/local/bin/aider \
+    && rm /tmp/requirements.txt
 
 # Verify installation
 RUN aider --version


### PR DESCRIPTION
Repairs the `Build All Agent Images` workflow (failing run [25591189142](https://github.com/HomericIntelligence/AchaeanFleet/actions/runs/25591189142), also 25528917397 and 25308898666).

## RC
`achaean-base-python` was upgraded to `python:3.14-slim`, but every released version of `aider-chat` (including the pinned `0.82.3` and the latest `0.86.x`) declares `Requires-Python: ">=3.10,<3.13"`. pip in the aider vessel build therefore could not resolve a distribution:

```
ERROR: Could not find a version that satisfies the requirement aider-chat==0.82.3
ERROR: No matching distribution found for aider-chat==0.82.3
```

Only the `achaean-aider` matrix entry failed; all other vessels are unaffected because they don't depend on Python 3.12-only packages.

## Fix
In `vessels/aider/Dockerfile`:

1. Add a `python:3.12-slim` source stage (digest-pinned).
2. `COPY --from=python312-source /usr/local /opt/python3.12` into the achaean-base-python image so a complete CPython 3.12 install is available without touching the shared base.
3. Build a venv with that interpreter at `/opt/aider-venv` and `pip install -r requirements.txt` into it.
4. Symlink `/opt/aider-venv/bin/aider` to `/usr/local/bin/aider` so existing `AGENT_PROGRAM=aider` wiring is unchanged.

`ARG BASE_IMAGE` is hoisted to a global (pre-first-FROM) ARG so the second stage can reference it — without this, BuildKit fails with `base name (${BASE_IMAGE}) should not be blank`.

`aider-chat==0.82.3` is preserved (still pinned for reproducibility per issue #2).

## Verified locally
- `hadolint --config .hadolint.yaml vessels/aider/Dockerfile` → clean.
- `DOCKER_BUILDKIT=1 docker build --build-arg BASE_IMAGE=<python:3.14-slim stand-in> -f vessels/aider/Dockerfile .` → succeeds.
- `aider --version` inside the built image → `aider 0.82.3`.

## Scope
1 file, +29 / -4 lines. Touches only `vessels/aider/Dockerfile` — no workflow, base-image, or agent application changes.