### PR TITLE
chore: easy-issue sweep — refs #599 #606

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Report a defect in AchaeanFleet
+title: "[BUG] "
+labels: bug
+assignees: ''
+---
+
+## Description
+
+A clear and concise description of the bug.
+
+## Steps to reproduce
+
+1. ...
+2. ...
+3. ...
+
+## Expected behavior
+
+What you expected to happen.
+
+## Actual behavior
+
+What actually happened. Include logs, error messages, and stack traces.
+
+## Environment
+
+- OS / distro:
+- Container runtime (podman / docker) and version:
+- AchaeanFleet branch / commit:
+- Compose file in use (e.g. `docker-compose.mesh.yml`):
+
+## Additional context
+
+Anything else that helps diagnose the issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,23 @@
+---
+name: Feature request
+about: Propose a new capability or enhancement
+title: "[FEATURE] "
+labels: enhancement
+assignees: ''
+---
+
+## Problem
+
+What problem are you trying to solve? Who is affected?
+
+## Proposed solution
+
+A clear and concise description of what you want to happen.
+
+## Alternatives considered
+
+Other approaches you considered and why they were rejected.
+
+## Additional context
+
+Links to related ADRs, issues, or external references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+Brief description of the change and the motivation.
+
+## Related issues
+
+Refs #<issue-number>
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Breaking change (fix or feature that changes existing behavior)
+- [ ] Documentation / chore
+
+## Test plan
+
+- [ ] Existing CI passes
+- [ ] Added or updated tests where applicable
+- [ ] Manually verified locally (describe how)
+
+## Checklist
+
+- [ ] Scope is focused (one logical change per PR)
+- [ ] No unrelated formatting / dependency churn
+- [ ] Documentation updated where behavior changed

--- a/compose/docker-compose.claude-only.yml
+++ b/compose/docker-compose.claude-only.yml
@@ -47,7 +47,6 @@ x-tmpfs: &tmpfs
   - /home/agent/.npm
   - /home/agent/.config
   - /home/agent/.local
-  - /home/agent/.npm
 
 x-logging: &default-logging
   driver: json-file

--- a/compose/docker-compose.mesh.yml
+++ b/compose/docker-compose.mesh.yml
@@ -91,7 +91,6 @@ x-tmpfs: &tmpfs
   - /home/agent/.npm
   - /home/agent/.config
   - /home/agent/.local
-  - /home/agent/.npm
 
 services:
   # -------------------------------------------------------------------------


### PR DESCRIPTION
Multi-issue sweep of severity:minor audit findings.

## Refs

- Refs #599 — Remove duplicate `/home/agent/.npm` entry from `x-tmpfs` YAML anchor in both `compose/docker-compose.mesh.yml` and `compose/docker-compose.claude-only.yml`.
- Refs #606 — Add `.github/ISSUE_TEMPLATE/bug_report.md`, `.github/ISSUE_TEMPLATE/feature_request.md`, and `.github/PULL_REQUEST_TEMPLATE.md`.

## Already-fixed (closed without PR changes)

- #605 — LICENSE already shows `Copyright (c) 2025-2026, HomericIntelligence Contributors` on `origin/main`.
- #600 / #598 — `compose/.env.example` no longer contains any merge conflict markers on `origin/main`; line 206 is `WORKER_CPU_RESERVATION=0.1`.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('compose/docker-compose.mesh.yml'))"` passes
- [x] `python3 -c "import yaml; yaml.safe_load(open('compose/docker-compose.claude-only.yml'))"` passes
- [ ] CI green