### PR TITLE
Forbid ::warning:: advisory pattern; pip-audit + 2 sites fail-fast

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -70,6 +70,35 @@ jobs:
           fi
           echo 'OK: no "continue-on-error: true" found'
 
+      - name: "Reject advisory annotation pattern"
+        run: |
+          set -euo pipefail
+          mapfile -t files < <(git ls-files -- '.github/workflows/*.yml' '.github/workflows/*.yaml')
+          # The advisory-annotation pattern in workflow run blocks is morally
+          # equivalent to continue-on-error: true: it lets a tool fail without
+          # failing the CI step. The runbook (Bucket F) requires every tool
+          # to be fail-fast. The only legitimate annotation is informational
+          # text not tied to a tool's exit code — those should use
+          # echo "WARN:" to stdout instead. See docs/runbooks/no-silent-failures.md.
+          declare -a scan_files=()
+          for f in "${files[@]}"; do
+            # Exempt this workflow file (heredoc would otherwise self-match).
+            case "$f" in
+              .github/workflows/_required.yml) continue ;;
+            esac
+            scan_files+=("$f")
+          done
+          if [ "${#scan_files[@]}" -eq 0 ]; then
+            echo "No files to scan"
+            exit 0
+          fi
+          if grep -nF '::warning::' "${scan_files[@]}"; then
+            echo ""
+            echo '::error::Found advisory annotations above. Make the underlying tool fail-fast or use echo "WARN:" to stdout. See docs/runbooks/no-silent-failures.md Bucket F.'
+            exit 1
+          fi
+          echo 'OK: no advisory annotations found'
+
   lint:
     name: lint
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,12 +241,76 @@ jobs:
           # pip install MUST succeed — if pip-audit or aider-chat can't be
           # installed, the audit step is meaningless.
           pip install --quiet pip-audit aider-chat
-          # pip-audit is advisory (CVE reporting): we print findings but do
-          # not fail the build on a non-zero exit. Capture exit code so it is
-          # visible in the job log rather than silently swallowed.
-          if ! pip-audit --desc --require aider-chat; then
-            echo "::warning::pip-audit reported issues for aider-chat (advisory; not failing the build)"
-          fi
+          # Fail-fast on findings — see docs/runbooks/no-silent-failures.md
+          # (Bucket F). The prior advisory annotation wrapper was a no-op
+          # masking the fact that the original `--require` flag never worked
+          # (it argparse-abbreviated to `--requirement`, which expects a
+          # requirements file path, not a package name).
+          #
+          # Allowlist below: 57 transitive CVEs in aider-chat's pinned deps
+          # tracked in HomericIntelligence/AchaeanFleet#655. Planned fix:
+          # upstream aider-chat bumps OR replace aider-chat. Review by
+          # 2026-08-10. Each ignore entry must be removed once the upstream
+          # fix lands. To audit without ignores: `pip-audit` against the
+          # installed env locally.
+          pip-audit --desc \
+            --ignore-vuln GHSA-2vrm-gr82-f7m5 \
+            --ignore-vuln GHSA-2xpw-w6gg-jr37 \
+            --ignore-vuln GHSA-38jv-5279-wg99 \
+            --ignore-vuln GHSA-3wq7-rqq7-wx6j \
+            --ignore-vuln GHSA-48p4-8xcf-vxj5 \
+            --ignore-vuln GHSA-4xh5-x5gv-qwph \
+            --ignore-vuln GHSA-5239-wwwm-4pmq \
+            --ignore-vuln GHSA-53mr-6c8q-9789 \
+            --ignore-vuln GHSA-54jq-c3m8-4m76 \
+            --ignore-vuln GHSA-58qw-9mgm-455v \
+            --ignore-vuln GHSA-5xmw-vc9v-4wf2 \
+            --ignore-vuln GHSA-63hf-3vf5-4wqf \
+            --ignore-vuln GHSA-63vm-454h-vhhq \
+            --ignore-vuln GHSA-69f9-5gxw-wvc2 \
+            --ignore-vuln GHSA-69x8-hrgq-fjj8 \
+            --ignore-vuln GHSA-6jhg-hg63-jvvf \
+            --ignore-vuln GHSA-6mq8-rvhq-8wgg \
+            --ignore-vuln GHSA-6vgw-5pg2-w6jp \
+            --ignore-vuln GHSA-735f-pc8j-v9w8 \
+            --ignore-vuln GHSA-7gcm-g887-7qv7 \
+            --ignore-vuln GHSA-8qvm-5x2c-j2w7 \
+            --ignore-vuln GHSA-9548-qrrj-x5pj \
+            --ignore-vuln GHSA-966j-vmvw-g2g9 \
+            --ignore-vuln GHSA-9hjg-9r4m-mvj7 \
+            --ignore-vuln GHSA-c427-h43c-vf67 \
+            --ignore-vuln GHSA-cfh3-3jmp-rvhc \
+            --ignore-vuln GHSA-cx63-2mw6-8hw5 \
+            --ignore-vuln GHSA-fh55-r93g-j68g \
+            --ignore-vuln GHSA-g84x-mcqj-x9qq \
+            --ignore-vuln GHSA-gc5v-m9x4-r6x2 \
+            --ignore-vuln GHSA-gm62-xv2j-4w53 \
+            --ignore-vuln GHSA-hcc4-c3v8-rx92 \
+            --ignore-vuln GHSA-jj3x-wxrx-4x23 \
+            --ignore-vuln GHSA-jjhc-v7c2-5hh6 \
+            --ignore-vuln GHSA-jp4c-xjxw-mgf9 \
+            --ignore-vuln GHSA-jr27-m4p2-rc6r \
+            --ignore-vuln GHSA-m5qp-6w8w-w647 \
+            --ignore-vuln GHSA-mf9w-mj56-hr94 \
+            --ignore-vuln GHSA-mqqc-3gqh-h2x8 \
+            --ignore-vuln GHSA-mv93-w799-cj2w \
+            --ignore-vuln GHSA-mwh4-6h8g-pg8w \
+            --ignore-vuln GHSA-p998-jp59-783m \
+            --ignore-vuln GHSA-pq67-6m6q-mj2v \
+            --ignore-vuln GHSA-pwv6-vv43-88gr \
+            --ignore-vuln GHSA-qmgc-5h2g-mvrw \
+            --ignore-vuln GHSA-r73j-pqj5-w3x7 \
+            --ignore-vuln GHSA-rpm5-65cw-6hj4 \
+            --ignore-vuln GHSA-v87r-6q3f-2j67 \
+            --ignore-vuln GHSA-w2fm-2cpv-w7v5 \
+            --ignore-vuln GHSA-w853-jp5j-5j7f \
+            --ignore-vuln GHSA-w8v5-vhqr-4h9v \
+            --ignore-vuln GHSA-whj4-6x5x-4v2j \
+            --ignore-vuln GHSA-wjx4-4jcj-g98j \
+            --ignore-vuln GHSA-x2qx-6953-8485 \
+            --ignore-vuln PYSEC-2022-43012 \
+            --ignore-vuln PYSEC-2025-49 \
+            --ignore-vuln PYSEC-2025-61
 
   validate:
     name: Validate Compose Files
@@ -825,20 +889,18 @@ jobs:
       - name: Verify compose network connectivity
         run: |
           set -euo pipefail
-          # Check that Docker internal DNS works for service names. This is
-          # advisory — a missing nslookup binary inside the slim worker image
-          # is expected and shouldn't fail the job, but daemon-level errors
-          # (compose exec failing entirely) should be reported.
-          if docker compose -f compose/docker-compose.smoke.yml exec -T hi-worker-smoke \
+          # Check that Docker internal DNS works for service names. A missing
+          # nslookup binary inside the slim worker image is expected and is
+          # handled inside the inner shell. Daemon-level errors (compose
+          # exec failing entirely) are real failures and must fail-fast — see
+          # docs/runbooks/no-silent-failures.md (Bucket F).
+          docker compose -f compose/docker-compose.smoke.yml exec -T hi-worker-smoke \
               sh -c 'if command -v nslookup >/dev/null 2>&1; then \
                        nslookup hi-worker-smoke; \
                      else \
                        echo "info: nslookup unavailable inside hi-worker-smoke (advisory)"; \
-                     fi'; then
-            echo "Network smoke test: OK (DNS check — advisory)"
-          else
-            echo "::warning::compose exec failed during DNS check (advisory; not failing the job)"
-          fi
+                     fi'
+          echo "Network smoke test: OK"
 
       - name: Tear down (always)
         if: always()

--- a/.github/workflows/shell-tests.yml
+++ b/.github/workflows/shell-tests.yml
@@ -43,14 +43,20 @@ jobs:
 
       - name: Check shell script test coverage
         run: |
+          # Informational only — emit WARN: lines to stdout. The GitHub Actions
+          # advisory-annotation form is forbidden by docs/runbooks/no-silent-failures.md
+          # (Bucket F) because it is morally equivalent to continue-on-error.
+          # Test coverage enforcement is tracked separately; if this signal
+          # ever becomes a hard requirement, replace the WARN: echoes with
+          # `exit 1` and add real coverage for each missing script first.
           missing=0
           for f in scripts/*.sh; do
             base=$(basename "$f" .sh)
             if ! ls tests/**/*"${base}"* 2>/dev/null | grep -q .; then
-              echo "WARNING: No test found for $f"
+              echo "WARN: No test found for $f"
               missing=$((missing + 1))
             fi
           done
           if [ "$missing" -gt 0 ]; then
-            echo "::warning::$missing shell script(s) have no corresponding test file"
+            echo "WARN: $missing shell script(s) have no corresponding test file"
           fi

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -125,3 +125,22 @@ repos:
         entry: '^\s*continue-on-error:\s*true\s*$'
         files: ^\.github/workflows/.*\.ya?ml$
         pass_filenames: true
+
+      - id: forbid-advisory-warnings
+        name: "forbid advisory ::warning:: pattern in workflow run blocks"
+        description: >
+          The advisory-warning workflow annotation is morally equivalent to
+          `continue-on-error: true` when it replaces a tool's failure exit
+          with a benign-looking warning. The CI step still passes, the
+          underlying problem still goes unfixed. Make the step fail-fast
+          instead. The only legitimate use is annotating a step that runs
+          BEFORE the failing tool (e.g., advising on a deprecated config),
+          not wrapping the tool's own exit. See docs/runbooks/no-silent-failures.md.
+        language: pygrep
+        # Match the GitHub Actions advisory-annotation prefix. We exempt
+        # this workflow file (the lint rule itself contains the literal
+        # for self-documentation) via the `exclude` regex below.
+        entry: '::warning::'
+        files: ^\.github/workflows/.*\.ya?ml$
+        exclude: ^\.github/workflows/_required\.yml$
+        pass_filenames: true


### PR DESCRIPTION
## Summary

- Ports the Bucket F regression guard from HomericIntelligence/Odysseus#282 (new `forbid-advisory-warnings` pygrep hook + matching CI step in `forbid-suppressions` job).
- Refactors 3 advisory `::warning::` sites to fail-fast.

## Sites refactored

| File:Line | Tool / Purpose | Before | After |
|---|---|---|---|
| `.github/workflows/ci.yml:247` | `pip-audit` (Python deps audit) | `if ! pip-audit --desc --require aider-chat; then echo "::warning::..."; fi` | `pip-audit --desc --ignore-vuln <57 IDs>` |
| `.github/workflows/ci.yml:904` | compose-exec DNS check | `if ! docker compose exec ...; then echo "::warning::compose exec failed..."; fi` | bare `docker compose exec ...` (fail-fast on daemon error) |
| `.github/workflows/shell-tests.yml:55` | shell-test coverage notice (informational only) | `echo "::warning::$missing shell script(s) ..."` | `echo "WARN: $missing shell script(s) ..."` |

> The brief listed 1 site (`ci.yml:247`). The new pygrep hook surfaced 2 additional pre-existing offenders that the prior silent-failures sweep (#654) missed — refactored here in the same PR for consistency.

## Critical finding — surfaced for user decision

The original `Audit Python dependencies (aider-chat)` step has been a **no-op** since pip-audit 2.x:

```yaml
# This NEVER ran a real audit:
pip-audit --desc --require aider-chat
# pip-audit: error: ambiguous option: --require could match --requirement, --require-hashes
```

`--require` argparse-abbreviates to `--requirement`, which expects a requirements file path, not a package name. The command exited immediately and the `if !` wrapper masked it as advisory. **No CVE audit has actually run in this repo's CI for weeks.**

A local run with `pip install pip-audit aider-chat && pip-audit --desc` surfaced **57 unique CVE IDs across 14 transitive packages**:

```
aiohttp, diskcache, filelock, gitpython, litellm, pillow, pip, protobuf,
pyasn1, pygments, python-dotenv, requests, setuptools, urllib3
```

All 57 IDs are now listed verbatim in the `--ignore-vuln` allowlist in `ci.yml` with an inline comment pointing at the tracked issue and review date. Full list and remediation paths captured in **#655** (planned review by 2026-08-10).

### User decision needed

Three valid resolutions (pick one in a follow-up):

1. Wait for upstream `aider-chat` to bump deps (recommended if pinned to latest release; prune ignores as they land).
2. Replace `aider-chat` with a different agent backend if upstream is unresponsive.
3. Drop the audit step entirely if aider-chat's transitive tree is permanently downstream-uncontrollable.

This PR takes the **minimum-risk path**: fix the broken invocation, make it fail-fast, allowlist the 57 known IDs with a tracked-issue reference. No CVE is silently accepted — each ignore is documented and time-boxed.

## Verification

- `pre-commit run --all-files` → all 3 forbid hooks pass (`forbid-or-true`, `forbid-continue-on-error`, `forbid-advisory-warnings`), plus all standard hygiene/yamllint/hadolint/shellcheck.
- Local `pip-audit --desc` against fresh `pip install aider-chat`: 57 known vulns, all now in allowlist.

Refs: HomericIntelligence/Odysseus#282, #655