### PR TITLE
chore: easy-issue sweep 2026-05-11

### DIFF
--- a/.github/workflows/digest-bump.yml
+++ b/.github/workflows/digest-bump.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo (fetch-depth 0 for full history)
-        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           fetch-depth: 0
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# AGENTS.md
+
+This repository follows the [`agents.md`](https://agents.md) convention for
+AI coding agents. The full agent guidance lives in [`CLAUDE.md`](./CLAUDE.md),
+which is the canonical instruction file for Claude, Codex, Cursor, and any
+other agentic coding tool that operates in this repo.
+
+Until divergent per-tool guidance is needed, treat `CLAUDE.md` as the source of
+truth for:
+
+- Project overview and architectural intent
+- Commands, build/test workflows, and `just` recipes
+- Coding conventions and forbidden patterns
+- Vessel layout and base-image relationships
+- CI/CD expectations and security guards
+
+If you are an AI agent: read [`CLAUDE.md`](./CLAUDE.md) first, then
+[`README.md`](./README.md) for human-facing context, then
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) for the contribution workflow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -172,6 +172,25 @@ HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
   CMD wget -qO- http://localhost:<PORT>/health 2>/dev/null || exit 1
 ```
 
+## Vessel CMD pattern
+
+AI-agent vessels (`claude`, `codex`, `aider`, `goose`, `cline`, `opencode`,
+`codebuff`, `ampcode`) **do not declare a Dockerfile `CMD`**. They inherit
+`ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]` from the base image, and
+`bases/entrypoint.sh` dispatches to `$AGENT_PROGRAM` (set per-vessel via
+`ENV AGENT_PROGRAM=<binary>`) with `$AGENT_HEADLESS_FLAG` appended. This
+keeps the launch contract uniform across vessels.
+
+The **only** vessel that overrides this is `worker`, which has no AI binary
+to run and instead serves the healthcheck endpoint directly:
+
+```dockerfile
+CMD ["node", "/app/healthcheck-server.js"]
+```
+
+When adding a new agent vessel, set `ENV AGENT_PROGRAM=...` (and optionally
+`ENV AGENT_HEADLESS_FLAG=...`) — do **not** add a `CMD`.
+
 ## Nomad
 
 See [`nomad/PATTERNS.md`](nomad/PATTERNS.md) for the full HCL authoring guide.

--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -12,6 +12,15 @@ LABEL org.opencontainers.image.title="achaean-base-minimal"
 LABEL org.opencontainers.image.description="AchaeanFleet minimal Debian base image for AI agent containers"
 LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/AchaeanFleet"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL git-sha=${GIT_SHA}
+
 # Install system dependencies
 # curl: required by Oh My Zsh installer in common-setup.sh
 RUN apt-get update && apt-get install -y \

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -12,6 +12,15 @@ LABEL org.opencontainers.image.title="achaean-base-python"
 LABEL org.opencontainers.image.description="AchaeanFleet Python base image for AI agent containers"
 LABEL org.opencontainers.image.source="https://github.com/HomericIntelligence/AchaeanFleet"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
+ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
+LABEL git-sha=${GIT_SHA}
+
 # Install system dependencies
 # curl: required by Oh My Zsh installer in common-setup.sh
 RUN apt-get update && apt-get install -y \

--- a/hephaestus/tags.py
+++ b/hephaestus/tags.py
@@ -11,7 +11,7 @@ Produces collision-safe tags per image push:
 from __future__ import annotations
 
 import re
-from datetime import date, timezone
+from datetime import date
 from typing import Sequence
 
 _DATE_TAG_RE = re.compile(r"^\d{4}-\d{2}-\d{2}-[0-9a-f]{7}$")

--- a/pods/claude-pod.yaml
+++ b/pods/claude-pod.yaml
@@ -40,7 +40,9 @@ spec:
             secretKeyRef:
               name: achaean-secrets
               key: anthropic-api-key
-              optional: true
+              # Required: Claude Code cannot authenticate without this key.
+              # Fail fast at pod startup rather than silently launching an
+              # agent that will hit 401s on first API call.
         - name: AGAMEMNON_URL
           value: "https://caddy:8443"
         - name: TLS_CA_CERT

--- a/vessels/goose/Dockerfile
+++ b/vessels/goose/Dockerfile
@@ -9,7 +9,13 @@ FROM ${BASE_IMAGE}
 LABEL org.opencontainers.image.title="achaean-goose"
 LABEL org.opencontainers.image.description="Goose (Block) AI agent vessel"
 
+ARG BUILD_DATE
+ARG VCS_REF
+ARG VERSION
 ARG GIT_SHA=unknown
+LABEL org.opencontainers.image.created=${BUILD_DATE}
+LABEL org.opencontainers.image.revision=${VCS_REF}
+LABEL org.opencontainers.image.version=${VERSION}
 LABEL git-sha=${GIT_SHA}
 
 USER root


### PR DESCRIPTION
Multi-issue sweep of severity:minor audit findings (2026-05-11 ecosystem-wide easy-issue wave).

## Implemented

- Closes #589 — Add `AGENTS.md` pointing to `CLAUDE.md` as canonical agent guidance.
- Closes #590 — Drop unused `timezone` import from `hephaestus/tags.py`.
- Closes #596 — Align `actions/checkout` SHA in `digest-bump.yml` with the rest of the repo (`de0fac2e...` v6.0.2).
- Closes #597 — Remove `optional: true` from the `ANTHROPIC_API_KEY` secretKeyRef in `pods/claude-pod.yaml`; pod now fails fast at start if the secret is missing instead of silently launching a Claude agent that will 401 on its first API call.
- Closes #602 — Document the "Vessel CMD pattern" in `CLAUDE.md` (entrypoint dispatches `$AGENT_PROGRAM`; only `worker` overrides with an explicit `CMD`).
- Closes #603 — Add full OCI labels (`created`/`revision`/`version` + `git-sha`) to `vessels/goose/Dockerfile`, `bases/Dockerfile.python`, and `bases/Dockerfile.minimal` so image provenance metadata is uniform across the fleet.

## Already-fixed (closed without PR changes)

- #591 — `dagger/pipeline.ts` already has inline explanatory comments next to each `@ts-ignore` (lines 116, 172, 229) on `main` (4f3aa94); audit-finding evidence is no longer accurate.
- #592 — `bases/common-setup.sh` header was corrected by PR #645 (merged); file now documents that it is a reference implementation not invoked by any Dockerfile.
- #599 — `x-tmpfs` YAML anchor duplicate `/home/agent/.npm` was removed by PR #653 in both `compose/docker-compose.mesh.yml` and `compose/docker-compose.claude-only.yml`.
- #606 — PR templates added by PR #653: `.github/ISSUE_TEMPLATE/{bug_report,feature_request}.md` and `.github/PULL_REQUEST_TEMPLATE.md`.

## Skipped (out of sweep scope — >50 LoC or requires deeper refactor)

- #593 — Pin Oh My Zsh installer to a specific commit SHA in `bases/Dockerfile.{python,minimal}`; needs network-verified pin choice + checksum strategy.
- #594 — `tests/test_entrypoint.bats` rewrite to call the actual script instead of simulating logic; >50 LoC test refactor.
- #595 — `security.yml` matrix scan across all three base images; requires job restructure + per-image availability tracking.
- #601 — Track Phase 6 vessel groups by issue number; meta-planning task, not a code change.
- #604 — `justfile check-versions` reading `versions.yml` instead of hardcoded values; >50 LoC justfile/yq rewrite.
- #610 — `dagger/pipeline.ts` POLA refactor of module-level vars; large architectural change, not a sweep candidate.

## Test plan

- [x] `pre-commit run --files <changed-files>` passes locally
- [x] All commits anchored on `origin/main` (4f3aa94)
- [ ] CI green