### PR TITLE
feat(security): add SHA256 verification for opencode and yq

### DIFF
--- a/tests/test_dockerfile_sha256_pins.py
+++ b/tests/test_dockerfile_sha256_pins.py
@@ -1,0 +1,182 @@
+"""
+Static analysis tests asserting that downloaded binaries are verified with SHA256 checksums.
+
+These tests verify:
+1. Both opencode and yq Dockerfiles contain sha256sum verification lines.
+2. Each per-arch ARG <TOOL>_<ARCH>_SHA256 contains a valid 64-char hex SHA256.
+3. The ARG default values match the corresponding entries in versions.yml.
+
+Run with: pytest tests/test_dockerfile_sha256_pins.py -v
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).parent.parent
+
+# Valid SHA256 is exactly 64 hex characters
+SHA256_PATTERN = re.compile(r"^[0-9a-f]{64}$", re.IGNORECASE)
+
+# ARG line matching: ARG <VAR_NAME>=<value>
+ARG_PATTERN = re.compile(r"^\s*ARG\s+(\w+)=([^\s]+)$", re.MULTILINE)
+
+# sha256sum check line: echo "..." | sha256sum --check
+SHA256SUM_CHECK_PATTERN = re.compile(r"echo\s+.*\|\s*sha256sum\s+--check")
+
+
+def _extract_args_from_dockerfile(text: str) -> dict[str, str]:
+    """Extract all ARG declarations from Dockerfile text as {name: value}."""
+    args = {}
+    for match in ARG_PATTERN.finditer(text):
+        name, value = match.groups()
+        args[name] = value
+    return args
+
+
+def _load_versions_yml() -> dict:
+    """Load and parse versions.yml."""
+    versions_file = REPO_ROOT / "versions.yml"
+    with open(versions_file, "r") as f:
+        return yaml.safe_load(f) or {}
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Both opencode and yq Dockerfiles have sha256sum --check
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel_path",
+    ["vessels/opencode/Dockerfile", "vessels/worker/Dockerfile"],
+    ids=lambda p: p.split("/")[1],
+)
+def test_sha256sum_check_present(rel_path: str) -> None:
+    """Dockerfile must contain a sha256sum --check line."""
+    dockerfile = REPO_ROOT / rel_path
+    if not dockerfile.exists():
+        pytest.skip(f"{rel_path} does not exist")
+
+    text = dockerfile.read_text()
+    assert SHA256SUM_CHECK_PATTERN.search(text), (
+        f"{rel_path}: missing 'sha256sum --check' verification line.\n"
+        "Binary downloads must verify the SHA256 checksum before extraction/installation."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Each per-arch ARG <TOOL>_<ARCH>_SHA256 is valid 64-char hex
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel_path,expected_args",
+    [
+        (
+            "vessels/opencode/Dockerfile",
+            ["OPENCODE_AMD64_SHA256", "OPENCODE_ARM64_SHA256"],
+        ),
+        ("vessels/worker/Dockerfile", ["YQ_AMD64_SHA256", "YQ_ARM64_SHA256"]),
+    ],
+    ids=lambda p: p[0].split("/")[1] if isinstance(p, tuple) else "",
+)
+def test_sha256_arg_format_valid(rel_path: str, expected_args: list[str]) -> None:
+    """Each per-arch ARG must be a valid 64-char hex SHA256."""
+    dockerfile = REPO_ROOT / rel_path
+    if not dockerfile.exists():
+        pytest.skip(f"{rel_path} does not exist")
+
+    text = dockerfile.read_text()
+    args = _extract_args_from_dockerfile(text)
+
+    violations = []
+    for arg_name in expected_args:
+        if arg_name not in args:
+            violations.append(f"missing ARG {arg_name}")
+            continue
+
+        sha256_value = args[arg_name]
+        if not SHA256_PATTERN.match(sha256_value):
+            violations.append(
+                f"ARG {arg_name}={sha256_value} is not a valid 64-char hex SHA256"
+            )
+
+    assert not violations, (
+        f"{rel_path}: SHA256 ARG validation failed:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Dockerfile ARG defaults match versions.yml
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "rel_path,tool_name",
+    [
+        ("vessels/opencode/Dockerfile", "opencode"),
+        ("vessels/worker/Dockerfile", "yq"),
+    ],
+    ids=lambda p: p[1],
+)
+def test_dockerfile_args_match_versions_yml(rel_path: str, tool_name: str) -> None:
+    """Verify Dockerfile SHA256 ARGs match versions.yml entries."""
+    dockerfile = REPO_ROOT / rel_path
+    if not dockerfile.exists():
+        pytest.skip(f"{rel_path} does not exist")
+
+    text = dockerfile.read_text()
+    dockerfile_args = _extract_args_from_dockerfile(text)
+    versions = _load_versions_yml()
+
+    tool_config = versions.get("tools", {}).get(tool_name)
+    if not tool_config:
+        pytest.skip(f"{tool_name} not found in versions.yml")
+
+    checksums = tool_config.get("checksums", {})
+    violations = []
+
+    for arch in ["amd64", "arm64"]:
+        arch_config = checksums.get(arch)
+        if not arch_config:
+            violations.append(f"versions.yml missing checksum for {arch}")
+            continue
+
+        yaml_sha256 = arch_config.get("sha256")
+        if yaml_sha256 is None:
+            violations.append(f"versions.yml has sha256: null for {arch}")
+            continue
+
+        # Map tool names and architectures to ARG names
+        if tool_name == "opencode":
+            arg_name = f"OPENCODE_{arch.upper()}_SHA256"
+        elif tool_name == "yq":
+            arg_name = f"YQ_{arch.upper()}_SHA256"
+        else:
+            violations.append(f"Unknown tool: {tool_name}")
+            continue
+
+        dockerfile_sha256 = dockerfile_args.get(arg_name)
+        if dockerfile_sha256 is None:
+            violations.append(f"Dockerfile missing ARG {arg_name}")
+            continue
+
+        if dockerfile_sha256 != yaml_sha256:
+            violations.append(
+                f"ARG {arg_name}={dockerfile_sha256} does not match "
+                f"versions.yml {tool_name}.checksums.{arch}.sha256={yaml_sha256}"
+            )
+
+    assert not violations, (
+        f"{rel_path} vs versions.yml consistency check failed:\n"
+        + "\n".join(f"  {v}" for v in violations)
+    )

--- a/versions.yml
+++ b/versions.yml
@@ -55,10 +55,10 @@ tools:
     checksums:
       amd64:
         asset: "opencode-linux-x64.tar.gz"
-        sha256: null  # TODO: add checksum verification to Dockerfile (see issue #210)
+        sha256: "34d503ebb029853293be6fd4d441bbb2dbb03919bfa4525e88b1ca55d68f3e17"
       arm64:
         asset: "opencode-linux-arm64.tar.gz"
-        sha256: null
+        sha256: "4cbf32f4c31da7dae14712b65aadbce6acfa1a7a85bee986a2ce4eaaed4eb5c8"
 
   yq:
     version: "v4.53.2"
@@ -68,10 +68,10 @@ tools:
     checksums:
       amd64:
         asset: "yq_linux_amd64"
-        sha256: null  # TODO: add checksum verification to Dockerfile
+        sha256: "d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b"
       arm64:
         asset: "yq_linux_arm64"
-        sha256: null
+        sha256: "03061b2a50c7a498de2bbb92d7cb078ce433011f085a4994117c2726be4106ea"
 
   yarn:
     version: "1.22.22"

--- a/vessels/opencode/Dockerfile
+++ b/vessels/opencode/Dockerfile
@@ -25,16 +25,19 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 ARG TARGETARCH=amd64
 # Pinned OpenCode version for reproducibility (issue #2). Update ENV to bump.
 ENV OPENCODE_VERSION=v1.4.3
+ARG OPENCODE_AMD64_SHA256=34d503ebb029853293be6fd4d441bbb2dbb03919bfa4525e88b1ca55d68f3e17
+ARG OPENCODE_ARM64_SHA256=4cbf32f4c31da7dae14712b65aadbce6acfa1a7a85bee986a2ce4eaaed4eb5c8
 
 # Install OpenCode binary at pinned version
 # opencode uses x64/arm64 naming (not amd64/arm64)
 RUN case "${TARGETARCH}" in \
-      amd64) OPENCODE_ARCH="x64" ;; \
-      arm64) OPENCODE_ARCH="arm64" ;; \
+      amd64) OPENCODE_ARCH="x64";   OPENCODE_SHA256="${OPENCODE_AMD64_SHA256}" ;; \
+      arm64) OPENCODE_ARCH="arm64"; OPENCODE_SHA256="${OPENCODE_ARM64_SHA256}" ;; \
       *) echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
     esac && \
     curl -fsSL "https://github.com/sst/opencode/releases/download/${OPENCODE_VERSION}/opencode-linux-${OPENCODE_ARCH}.tar.gz" \
         -o /tmp/opencode.tar.gz && \
+    echo "${OPENCODE_SHA256}  /tmp/opencode.tar.gz" | sha256sum --check && \
     tar -xzf /tmp/opencode.tar.gz -C /usr/local/bin && \
     chmod +x /usr/local/bin/opencode && \
     rm -f /tmp/opencode.tar.gz

--- a/vessels/worker/Dockerfile
+++ b/vessels/worker/Dockerfile
@@ -27,14 +27,22 @@ USER root
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG TARGETARCH=amd64
+ARG YQ_AMD64_SHA256=d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b
+ARG YQ_ARM64_SHA256=03061b2a50c7a498de2bbb92d7cb078ce433011f085a4994117c2726be4106ea
 
 # Install required tools — failures here are fatal
 RUN apt-get update && \
     apt-get install -y jq make && \
     rm -rf /var/lib/apt/lists/* && \
+    case "${TARGETARCH}" in \
+      amd64) YQ_SHA256="${YQ_AMD64_SHA256}" ;; \
+      arm64) YQ_SHA256="${YQ_ARM64_SHA256}" ;; \
+      *) echo "Unsupported arch: ${TARGETARCH}" && exit 1 ;; \
+    esac && \
     ( which yq || ( \
         curl -fsSL "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_${TARGETARCH}" \
             -o /usr/local/bin/yq && \
+        echo "${YQ_SHA256}  /usr/local/bin/yq" | sha256sum --check && \
         chmod +x /usr/local/bin/yq ) )
 
 COPY vessels/worker/healthcheck-server.js /app/healthcheck-server.js


### PR DESCRIPTION
## Summary

Add build-time SHA256 checksum verification to opencode and yq binary downloads in vessel Dockerfiles. Both tools are now verified before extraction to close a supply chain integrity gap.

## Changes

- **vessels/opencode/Dockerfile**: Added per-arch SHA256 ARG declarations and sha256sum --check before tar extraction
- **vessels/worker/Dockerfile**: Added per-arch SHA256 ARG declarations and sha256sum --check for yq binary
- **versions.yml**: Filled in verified SHA256 values for opencode and yq (issue #210)
- **tests/test_dockerfile_sha256_pins.py**: New test file verifying SHA256 presence, format, and consistency

All checksums verified against upstream release assets.

## Test Plan

- [x] All existing tests pass (npm/pip version pins, no latest releases)
- [x] New SHA256 verification tests pass (presence, format, consistency)
- [x] Static analysis confirms ARG values match versions.yml entries
- [x] Local build test: `docker build -f vessels/opencode/Dockerfile --build-arg BASE_IMAGE=... .` succeeds
- [x] Local build test: `docker build -f vessels/worker/Dockerfile --build-arg BASE_IMAGE=... .` succeeds

Closes #582

🤖 Generated with [Claude Code](https://claude.com/claude-code)