### PR TITLE
cleanup(tests): remove placeholder test_smoke.py (#579)

### DIFF
--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -1,2 +1,0 @@
-def test_smoke() -> None:
-    assert True


### PR DESCRIPTION
## Summary

- Removes `tests/test_smoke.py` which contained only `def test_smoke() -> None: assert True` — a zero-signal placeholder with no behavioral coverage
- Real smoke testing already lives in the CI `test-smoke` job (`.github/workflows/ci.yml`) which exercises `compose/docker-compose.smoke.yml` against the worker vessel
- All 182 remaining pytest tests pass after deletion; no external references to `test_smoke` exist anywhere in the repo

## Verification

- `grep -rn "test_smoke" .` returns nothing after deletion
- `pytest tests/ --collect-only | grep test_smoke` returns nothing
- `pytest tests/ -v` → 182 passed in 2.62s

## Divergence from Plan

None. Plan stated line 841 of ci.yml; actual `test-smoke` job is at line 776 — immaterial, job exists and is functional.

Closes #579
Refs #576

🤖 Generated with [Claude Code](https://claude.com/claude-code)