### PR TITLE
feat(nomad): wire Vault secrets for claude-agents and aider-agents (#585)

### DIFF
--- a/nomad/PATTERNS.md
+++ b/nomad/PATTERNS.md
@@ -90,10 +90,11 @@ service {
 
 ## 5. Secrets Management (Phase 6 Vault Integration)
 
-**Current state (Phases 1–5):**
-API keys and other secrets are **not yet wired** into the Nomad job spec. When Phase 6
-is implemented, secrets must be injected dynamically from Vault, never stored in HCL
-or passed as plain environment variables.
+**Current state:**
+Secrets are wired for claude and aider groups in `mesh.nomad.hcl`; see the
+`vault { policies = ["achaean-secrets"] }` job stanza and per-group `template` stanzas.
+Secrets must be injected dynamically from Vault — never stored in HCL or passed as
+plain environment variables.
 
 **When implementing (Phase 6+):**
 

--- a/nomad/mesh.nomad.hcl
+++ b/nomad/mesh.nomad.hcl
@@ -10,9 +10,9 @@
 # Override variables at run time:
 #   nomad job run -var="agamemnon_url=http://192.168.1.10:8080" nomad/mesh.nomad.hcl
 #
-# SECRETS MANAGEMENT (Phase 6):
-# API keys and dynamic secrets are injected via Nomad's Vault integration.
-# See nomad/PATTERNS.md § 5 for the template stanza pattern and anti-patterns to avoid.
+# SECRETS MANAGEMENT:
+# Vault integration is wired for claude-agents and aider-agents groups.
+# See nomad/PATTERNS.md §5 for the template stanza pattern and anti-patterns to avoid.
 # Never pass secrets as inline env vars or store them in HCL.
 
 # =============================================================================
@@ -61,6 +61,10 @@ job "achaean-mesh" {
     canary           = 0
   }
 
+  vault {
+    policies = ["achaean-secrets"]
+  }
+
   # -------------------------------------------------------------------------
   # Claude agents group
   # -------------------------------------------------------------------------
@@ -107,16 +111,17 @@ EOT
         env         = true
       }
 
-      # Secrets via Nomad Vault integration (Phase 6)
-      # template {
-      #   data = <<EOH
-      #   {{ with secret "secret/achaean/claude" }}
-      #   ANTHROPIC_API_KEY={{ .Data.api_key }}
-      #   {{ end }}
-      #   EOH
-      #   destination = "secrets/env"
-      #   env         = true
-      # }
+      # Secrets via Nomad Vault integration
+      template {
+        data = <<EOH
+{{ with secret "secret/data/achaean/claude" }}
+ANTHROPIC_API_KEY={{ .Data.data.anthropic_api_key }}
+{{ end }}
+EOH
+        destination = "secrets/env"
+        env         = true
+        change_mode = "restart"
+      }
 
       resources {
         cpu    = 2000  # MHz
@@ -179,6 +184,18 @@ AGENT_ID="aider-{{ env "NOMAD_ALLOC_INDEX" }}"
 EOT
         destination = "local/runtime-env.env"
         env         = true
+      }
+
+      # Secrets via Nomad Vault integration
+      template {
+        data = <<EOH
+{{ with secret "secret/data/achaean/aider" }}
+ANTHROPIC_API_KEY={{ .Data.data.anthropic_api_key }}
+{{ end }}
+EOH
+        destination = "secrets/env"
+        env         = true
+        change_mode = "restart"
       }
 
       resources {

--- a/tests/test_nomad_vault_integration.py
+++ b/tests/test_nomad_vault_integration.py
@@ -1,0 +1,116 @@
+"""Static regex tests for Vault integration in nomad/mesh.nomad.hcl.
+
+Validates that:
+- A job-level vault {} block with the correct policy is present.
+- claude-agents task has a KV v2 template stanza for ANTHROPIC_API_KEY.
+- aider-agents task has a KV v2 template stanza for ANTHROPIC_API_KEY.
+- All Vault template stanzas use destination = "secrets/env" and env = true.
+- No KV v1 paths (missing /data/ segment) are present.
+- No inline secrets (sk- prefixed keys) are present.
+- All .Data. references use the KV v2 form .Data.data.<field>.
+"""
+
+import re
+from pathlib import Path
+
+NOMAD_JOB = Path(__file__).parent.parent / "nomad" / "mesh.nomad.hcl"
+
+
+def _text() -> str:
+    return NOMAD_JOB.read_text()
+
+
+def test_job_level_vault_block_present() -> None:
+    """Job must contain a vault {} block with the achaean-secrets policy."""
+    text = _text()
+    assert re.search(r'vault\s*\{', text), "No vault { block found in job spec"
+    assert 'policies = ["achaean-secrets"]' in text, (
+        'vault block must contain policies = ["achaean-secrets"]'
+    )
+
+
+def test_claude_agents_vault_template_path() -> None:
+    """claude-agents task must reference the KV v2 path secret/data/achaean/claude."""
+    text = _text()
+    assert 'secret/data/achaean/claude' in text, (
+        "claude-agents template must use KV v2 path: secret/data/achaean/claude"
+    )
+
+
+def test_claude_agents_anthropic_api_key_field() -> None:
+    """claude-agents template must extract ANTHROPIC_API_KEY with correct field syntax."""
+    text = _text()
+    assert 'ANTHROPIC_API_KEY={{ .Data.data.anthropic_api_key }}' in text, (
+        "claude-agents template must set ANTHROPIC_API_KEY={{ .Data.data.anthropic_api_key }}"
+    )
+
+
+def test_aider_agents_vault_template_path() -> None:
+    """aider-agents task must reference the KV v2 path secret/data/achaean/aider."""
+    text = _text()
+    assert 'secret/data/achaean/aider' in text, (
+        "aider-agents template must use KV v2 path: secret/data/achaean/aider"
+    )
+
+
+def test_aider_agents_anthropic_api_key_field() -> None:
+    """aider-agents template must extract ANTHROPIC_API_KEY with correct field syntax."""
+    text = _text()
+    # Both claude and aider use the same field name — count occurrences to confirm both
+    occurrences = text.count('ANTHROPIC_API_KEY={{ .Data.data.anthropic_api_key }}')
+    assert occurrences >= 2, (
+        f"Expected ANTHROPIC_API_KEY extraction in at least 2 template stanzas, found {occurrences}"
+    )
+
+
+def test_vault_templates_use_secrets_destination() -> None:
+    """All Vault secret template stanzas must write to secrets/env."""
+    text = _text()
+    # Every occurrence of secret/data/achaean/ must be in a template that targets secrets/env
+    vault_template_count = len(re.findall(r'secret/data/achaean/', text))
+    secrets_env_count = text.count('destination = "secrets/env"')
+    assert secrets_env_count >= vault_template_count, (
+        f"Expected at least {vault_template_count} 'destination = \"secrets/env\"' stanzas, "
+        f"found {secrets_env_count}"
+    )
+
+
+def test_vault_templates_have_env_true() -> None:
+    """Vault secret template stanzas must set env = true."""
+    text = _text()
+    # secrets/env destination blocks must include env = true
+    # We check that env = true appears at least as many times as vault secret paths
+    vault_template_count = len(re.findall(r'secret/data/achaean/', text))
+    env_true_count = len(re.findall(r'env\s*=\s*true', text))
+    assert env_true_count >= vault_template_count, (
+        f"Expected at least {vault_template_count} 'env = true' in Vault template stanzas, "
+        f"found {env_true_count}"
+    )
+
+
+def test_no_kv1_paths() -> None:
+    """No KV v1 paths (secret/<name> without /data/ segment) must be present."""
+    text = _text()
+    # Match secret "secret/achaean/<anything>" — missing /data/ = KV v1
+    matches = re.findall(r'secret\s+"secret/achaean/', text)
+    assert not matches, (
+        f"Found KV v1 path(s) (missing /data/ segment): {matches}. "
+        "Use secret/data/achaean/<name> instead."
+    )
+
+
+def test_no_inline_secrets() -> None:
+    """No inline API key literals (sk- prefix) must appear in the job spec."""
+    text = _text()
+    matches = re.findall(r'(?i)(api[_-]?key|secret)\s*=\s*"sk-[a-zA-Z0-9]', text)
+    assert not matches, f"Found inline secret(s) in job spec: {matches}"
+
+
+def test_no_kv1_data_field_syntax() -> None:
+    """All .Data. references must use KV v2 form (.Data.data.<field>), not bare .Data.<field>."""
+    text = _text()
+    # Match .Data. followed by a word that is NOT "data" (i.e. KV v1 bare field access)
+    kv1_refs = re.findall(r'\.Data\.(?!data\b)\w+', text)
+    assert not kv1_refs, (
+        f"Found KV v1-style .Data.<field> references (should be .Data.data.<field>): {kv1_refs}"
+    )


### PR DESCRIPTION
## Summary

- Add job-level `vault { policies = ["achaean-secrets"] }` stanza (no `change_mode` in vault block — that attribute belongs only in `template` stanzas per Plan Review major finding)
- Replace commented KV v1 stub in `claude-agents` (lines 110–119) with live KV v2 template: `secret/data/achaean/claude` → `ANTHROPIC_API_KEY` via `.Data.data.anthropic_api_key`
- Add equivalent Vault template to `aider-agents` after the runtime-env template: `secret/data/achaean/aider` → `ANTHROPIC_API_KEY` only (YAGNI: `AIDER_MODEL=claude-3-5-sonnet-20241022`, no `OPENAI_API_KEY` needed)
- `worker-agents` left unchanged (no AI binary; no API key required in Phase 6 scope)
- Update `nomad/PATTERNS.md` §5 from "not yet wired" to reflect wired status
- Add `tests/test_nomad_vault_integration.py` with 10 static regex assertions (KV v2 paths, correct field names, `destination = "secrets/env"`, `env = true`, no KV v1 leftovers, no inline secrets)

## Plan vs. Current Divergence

None. The plan's line numbers matched the actual file exactly. The Plan Review's major finding (remove `change_mode` from the `vault {}` block — it is not a valid vault stanza attribute) was applied: the job-level `vault {}` contains only `policies`.

## Verification

- All 10 new static tests pass: `pytest tests/test_nomad_vault_integration.py -v`
- Full test suite (193 tests) passes with no regressions: `pytest tests/ -k 'not bats'`
- No inline secrets in `nomad/mesh.nomad.hcl` (grep confirmed)
- `nomad` CLI not available locally; runtime Vault connectivity test requires a live cluster (Phase 6 deployment gate)

Closes #585

🤖 Generated with [Claude Code](https://claude.com/claude-code)