### PR TITLE
feat(ci): disable achaean-aider vessel in release.yml, justfile, scripts, nomad (#665)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -73,6 +73,9 @@ updates:
     reviewers:
       - "mvillmow"
 
+  # vessels/aider Dependabot monitoring intentionally kept per #665 Decision F:
+  # Dependabot PRs signal upstream pin improvements and serve as the cheapest
+  # re-enable indicator. CI will reject those PRs until #665 is reverted.
   - package-ecosystem: "docker"
     directory: "/vessels/aider"
     schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,10 +26,7 @@ jobs:
             dockerfile: vessels/codex/Dockerfile
             base: achaean-base-node
             base_dockerfile: bases/Dockerfile.node
-          - name: achaean-aider
-            dockerfile: vessels/aider/Dockerfile
-            base: achaean-base-python
-            base_dockerfile: bases/Dockerfile.python
+          # achaean-aider disabled — see #665. Re-enable by restoring the 4-line matrix entry here.
           - name: achaean-goose
             dockerfile: vessels/goose/Dockerfile
             base: achaean-base-minimal

--- a/justfile
+++ b/justfile
@@ -18,7 +18,7 @@ tag := env_var_or_default("TAG", "latest")
 
 bases := "achaean-base-node achaean-base-python achaean-base-minimal"
 
-vessels := "claude codex aider goose cline opencode codebuff ampcode worker"
+vessels := "claude codex goose cline opencode codebuff ampcode worker"  # achaean-aider excluded per #665
 
 # Auto-detect container runtime: prefer podman, fall back to docker
 container_cmd := `which podman 2>/dev/null && echo podman || echo docker`
@@ -180,7 +180,7 @@ build-vessel NAME:
     container_cmd="$(which podman 2>/dev/null || echo docker)"
     case "{{NAME}}" in
         claude|codex|cline|codebuff|ampcode) base="achaean-base-node" ;;
-        aider)                               base="achaean-base-python" ;;
+        # aider disabled — see #665; restore: aider) base="achaean-base-python" ;;
         goose|opencode|worker)               base="achaean-base-minimal" ;;
         *) echo "Unknown vessel: {{NAME}}"; exit 1 ;;
     esac
@@ -204,14 +204,15 @@ build-all:
     CONTAINER_CMD={{container_cmd}} bash scripts/build-all.sh
     @echo "=== All images built ==="
 
-# Verify all 9 vessel images exist locally (podman or docker)
+# Verify all vessel images exist locally (podman or docker)
+# Note: achaean-aider excluded per #665 (CVE chain); restore by adding 'aider' to the loop below.
 verify:
     #!/usr/bin/env bash
     set -euo pipefail
     container_cmd="$(which podman 2>/dev/null || echo docker)"
     echo "Verifying images with: ${container_cmd}"
     failed=0
-    for vessel in claude codex aider goose cline opencode codebuff ampcode worker; do
+    for vessel in claude codex goose cline opencode codebuff ampcode worker; do
         if ${container_cmd} image exists "achaean-${vessel}:latest" 2>/dev/null || \
            ${container_cmd} inspect "achaean-${vessel}:latest" &>/dev/null; then
             echo "  ✓ achaean-${vessel}:latest"

--- a/nomad/mesh.nomad.hcl
+++ b/nomad/mesh.nomad.hcl
@@ -143,6 +143,10 @@ EOT
 
   # -------------------------------------------------------------------------
   # Aider agents group (Python)
+  # DISABLED per #665 — achaean-aider:latest is NOT produced by CI (CVE chain in
+  # aider-chat transitive deps). DO NOT run `nomad job run` against this group
+  # until #665 is re-enabled and a GHCR image exists. The group is retained here
+  # so re-enabling is a trivial revert of the #665 CI changes.
   # -------------------------------------------------------------------------
   group "aider-agents" {
     count = 1

--- a/scripts/build-all.sh
+++ b/scripts/build-all.sh
@@ -76,7 +76,7 @@ build_image "achaean-codebuff:${TAG}" "vessels/codebuff/Dockerfile" --build-arg 
 build_image "achaean-ampcode:${TAG}"  "vessels/ampcode/Dockerfile"  --build-arg "BASE_IMAGE=achaean-base-node:${TAG}"   "${OCI_BUILD_ARGS[@]}"
 
 # Python-based vessels
-build_image "achaean-aider:${TAG}" "vessels/aider/Dockerfile" --build-arg "BASE_IMAGE=achaean-base-python:${TAG}" "${OCI_BUILD_ARGS[@]}"
+# achaean-aider disabled — see #665. Restore: build_image "achaean-aider:${TAG}" "vessels/aider/Dockerfile" --build-arg "BASE_IMAGE=achaean-base-python:${TAG}" "${OCI_BUILD_ARGS[@]}"
 
 # Minimal-based vessels
 build_image "achaean-goose:${TAG}"    "vessels/goose/Dockerfile"    --build-arg "BASE_IMAGE=achaean-base-minimal:${TAG}" "${OCI_BUILD_ARGS[@]}"

--- a/scripts/tag-images.sh
+++ b/scripts/tag-images.sh
@@ -29,7 +29,7 @@ REGISTRY="${REGISTRY:-}"
 ALL_VESSELS=(
   achaean-claude
   achaean-codex
-  achaean-aider
+  # achaean-aider disabled — see #665. Restore by un-commenting this line.
   achaean-goose
   achaean-cline
   achaean-opencode

--- a/tests/test_aider_disabled.py
+++ b/tests/test_aider_disabled.py
@@ -1,0 +1,144 @@
+"""
+Guard tests asserting that achaean-aider remains disabled in CI per issue #665.
+
+These tests are intentionally inverted: they PASS when aider is absent from CI
+matrices and FAIL when it reappears, signalling that the PR needs to also update
+this file (removing it) as part of the re-enable process.
+
+Re-enabling aider:
+  1. Verify upstream aider-chat has cleaner transitive pins (see #665 body).
+  2. Revert every #665-marked hunk in: ci.yml, release.yml, justfile, scripts/,
+     nomad/mesh.nomad.hcl, dependabot.yml.
+  3. Delete this file (tests/test_aider_disabled.py).
+  4. Run: pixi run pytest
+
+Run with: pytest tests/ -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_yaml(rel_path: str) -> dict:
+    """Load a YAML file relative to REPO_ROOT."""
+    path = REPO_ROOT / rel_path
+    assert path.exists(), f"Expected file not found: {rel_path}"
+    with path.open() as fh:
+        return yaml.safe_load(fh)
+
+
+def _vessel_names_from_matrix(matrix_vessels: list[dict]) -> list[str]:
+    """Extract vessel names from a YAML matrix list (skipping None entries)."""
+    return [entry["name"] for entry in matrix_vessels if entry is not None]
+
+
+# ---------------------------------------------------------------------------
+# ci.yml assertions
+# ---------------------------------------------------------------------------
+
+
+def test_aider_absent_from_ci_build_matrix() -> None:
+    """achaean-aider must not appear in ci.yml build-vessels matrix."""
+    ci = _load_yaml(".github/workflows/ci.yml")
+    build_vessels_job = ci["jobs"]["build-vessels"]
+    matrix_vessels = build_vessels_job["strategy"]["matrix"]["vessel"]
+    names = _vessel_names_from_matrix(matrix_vessels)
+    assert "achaean-aider" not in names, (
+        "achaean-aider found in ci.yml build-vessels matrix — "
+        "vessel must remain disabled per #665."
+    )
+
+
+def test_aider_absent_from_ci_push_matrix() -> None:
+    """achaean-aider must not appear in ci.yml push-to-registry matrix."""
+    ci = _load_yaml(".github/workflows/ci.yml")
+    push_job = ci["jobs"]["push-to-registry"]
+    matrix_vessels = push_job["strategy"]["matrix"]["vessel"]
+    names = _vessel_names_from_matrix(matrix_vessels)
+    assert "achaean-aider" not in names, (
+        "achaean-aider found in ci.yml push-to-registry matrix — "
+        "vessel must remain disabled per #665."
+    )
+
+
+def test_aider_absent_from_ci_verify_array() -> None:
+    """achaean-aider must not appear as an active entry in the ci.yml
+    verify-registry vessels shell array (comment lines are acceptable)."""
+    ci_path = REPO_ROOT / ".github/workflows/ci.yml"
+    assert ci_path.exists(), "ci.yml not found"
+    in_verify = False
+    in_vessels_array = False
+    for line in ci_path.read_text().splitlines():
+        stripped = stripped_no_comment = line.strip()
+        # Remove inline comments for the active-entry check
+        if "#" in stripped:
+            stripped_no_comment = stripped[: stripped.index("#")].strip()
+
+        if "verify-registry:" in stripped:
+            in_verify = True
+        if in_verify and 'vessels=(' in stripped_no_comment:
+            in_vessels_array = True
+        if in_vessels_array and stripped_no_comment == ")":
+            in_vessels_array = False
+            in_verify = False
+        if in_vessels_array:
+            # Active (non-comment) line containing achaean-aider is a failure
+            if "achaean-aider" in stripped_no_comment:
+                pytest.fail(
+                    "achaean-aider is an active entry in ci.yml verify-registry "
+                    "vessels array — must remain disabled per #665."
+                )
+
+
+# ---------------------------------------------------------------------------
+# release.yml assertions
+# ---------------------------------------------------------------------------
+
+
+def test_aider_absent_from_release_matrix() -> None:
+    """achaean-aider must not appear in release.yml release job matrix."""
+    release = _load_yaml(".github/workflows/release.yml")
+    release_job = release["jobs"]["release"]
+    matrix_vessels = release_job["strategy"]["matrix"]["vessel"]
+    names = _vessel_names_from_matrix(matrix_vessels)
+    assert "achaean-aider" not in names, (
+        "achaean-aider found in release.yml matrix — "
+        "vessel must remain disabled per #665 to prevent CVE-exposed image pushes."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artifact retention assertions (re-enable precondition)
+# ---------------------------------------------------------------------------
+
+
+_AIDER_ARTIFACTS = [
+    "vessels/aider/Dockerfile",
+    "vessels/aider/requirements.txt",
+    "vessels/aider/requirements-security-overrides.txt",
+]
+
+
+@pytest.mark.parametrize("rel_path", sorted(_AIDER_ARTIFACTS))
+def test_aider_artifacts_retained(rel_path: str) -> None:
+    """Retained aider artifacts must still exist on disk.
+
+    These files are intentionally kept so that re-enabling aider is a
+    mechanical revert of #665 CI changes rather than a reconstruction.
+    If any of these files are accidentally deleted, the re-enable path
+    becomes significantly more expensive.
+    """
+    assert (REPO_ROOT / rel_path).exists(), (
+        f"Aider artifact unexpectedly deleted: {rel_path}. "
+        "This file must be retained on disk per #665 — restore it."
+    )

--- a/tests/test_dockerfile_version_pins.py
+++ b/tests/test_dockerfile_version_pins.py
@@ -197,7 +197,7 @@ _EXPECTED_DOCKERFILES = [
     "bases/Dockerfile.node",
     "bases/Dockerfile.python",
     "vessels/claude/Dockerfile",
-    "vessels/aider/Dockerfile",
+    "vessels/aider/Dockerfile",  # retained on disk per #665; CI build disabled, re-enable is a revert
     "vessels/ampcode/Dockerfile",
     "vessels/cline/Dockerfile",
     "vessels/codebuff/Dockerfile",


### PR DESCRIPTION
## Summary

Completes the aider CI disable started in #662. PR #662 removed achaean-aider from `ci.yml` lint/pip-audit/build/push/verify steps and `dagger/pipeline.ts`. This PR closes the remaining active build/push paths that were missed:

- **`.github/workflows/release.yml`**: removed `achaean-aider` matrix entry — this was still building and pushing CVE-exposed images to GHCR on every `vX.Y.Z` tag (the critical gap identified in the plan review)
- **`justfile`**: removed `aider` from `vessels` var, `build-vessel` case, and `verify` loop; all marked with `#665` restore comments
- **`scripts/build-all.sh`**: commented out `achaean-aider` `build_image` call with `#665` marker
- **`scripts/tag-images.sh`**: commented out `achaean-aider` in `ALL_VESSELS` with `#665` marker
- **`nomad/mesh.nomad.hcl`**: added `DISABLED per #665` hazard comment above `aider-agents` group (group structure retained; image no longer produced by any CI job)
- **`.github/dependabot.yml`**: added comment explaining `/vessels/aider` monitoring is intentionally kept as the upstream-pin re-enable signal (Decision F)
- **`tests/test_dockerfile_version_pins.py`**: added retention comment at the `vessels/aider/Dockerfile` entry
- **`tests/test_aider_disabled.py`** (new): guard test asserting aider is absent from all four CI matrices (ci.yml build, ci.yml push, ci.yml verify, release.yml) and that retained on-disk artifacts still exist

All `vessels/aider/` artifacts, compose services, and the Nomad `aider-agents` group are **retained on disk** — re-enabling is a mechanical revert of `#665`-marked hunks.

## Divergence from plan comment

The plan comment in the issue said "Status: IMPLEMENTED" but the plan review confirmed nothing was actually committed. Implemented from scratch in this PR; all plan decisions (A-F) faithfully executed.

## Test plan

- [ ] `pixi run pytest` passes (guard test `test_aider_disabled.py` + full suite)
- [ ] `bash -n scripts/build-all.sh && bash -n scripts/tag-images.sh` — syntax OK
- [ ] `grep -rn 'achaean-aider' .github/workflows/` — all hits are comment lines
- [ ] CI `validate-nomad` job covers the comment-only HCL change
- [ ] `release.yml` structural check: 8 vessels, no `achaean-aider`

Closes #665

🤖 Generated with [Claude Code](https://claude.com/claude-code)