### PR TITLE
fix(security): suppress unfixable yq Go stdlib CVEs in achaean-worker (#658)

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -231,3 +231,27 @@ CVE-2026-39836
 # Expires: 2026-08-14
 # Reviewer: @mvillmow  PR #662
 CVE-2026-42499
+
+# CVE-2026-39823
+# Category: other
+# Rationale: Go stdlib URL canonicalization — embedded in /usr/local/bin/yq (mikefarah/yq v4.53.2 built with Go 1.26.2). Fixed in Go 1.25.10 / 1.26.3; no newer yq release available as of 2026-05-29 that bundles a patched Go toolchain.
+# Exploitability: none — yq in the achaean-worker vessel processes only local YAML files and does not handle attacker-controlled URLs.
+# Expires: 2026-08-27
+# Reviewer: @mvillmow  PR #658
+CVE-2026-39823
+
+# CVE-2026-39825
+# Category: other
+# Rationale: Go stdlib net/http ReverseProxy query parameter forwarding — embedded in /usr/local/bin/yq (mikefarah/yq v4.53.2 built with Go 1.26.2). Fixed in Go 1.25.10 / 1.26.3; no newer yq release available as of 2026-05-29.
+# Exploitability: none — yq in the achaean-worker vessel is a YAML processor; it does not act as an HTTP reverse proxy and does not forward query parameters.
+# Expires: 2026-08-27
+# Reviewer: @mvillmow  PR #658
+CVE-2026-39825
+
+# CVE-2026-39826
+# Category: other
+# Rationale: Go stdlib html/template XSS via trusted template author script tag — embedded in /usr/local/bin/yq (mikefarah/yq v4.53.2 built with Go 1.26.2). Fixed in Go 1.25.10 / 1.26.3; no newer yq release available as of 2026-05-29.
+# Exploitability: none — yq in the achaean-worker vessel processes YAML, not HTML templates; the html/template code path is unreachable in this usage.
+# Expires: 2026-08-27
+# Reviewer: @mvillmow  PR #658
+CVE-2026-39826


### PR DESCRIPTION
## Summary

- Adds three `.trivyignore` entries for Go stdlib CVEs in `/usr/local/bin/yq` (mikefarah/yq v4.53.2, built with Go 1.26.2) that cause the `Build Vessel Images (achaean-worker)` job to fail on `main`.
- CVEs affected: `CVE-2026-39823` (URL canonicalization), `CVE-2026-39825` (ReverseProxy query forwarding), `CVE-2026-39826` (html/template XSS) — all fixed in Go 1.25.10/1.26.3.
- No newer yq release is available as of 2026-05-29 that bundles Go 1.26.3; suppression follows SECURITY.md criterion 4(b). Entries expire 2026-08-27.

## Plan divergence from issue comment spec

The original plan (written 2026-05-16) targeted two failures: npm audit advisories (Job A) and Trivy CVEs in base images (Job B). Both of those are already resolved in current `main`:
- **Job A** (`Validate Dagger Pipeline` / npm audit): The `overrides` block in `dagger/package.json` (protobufjs, @opentelemetry/exporter-prometheus) was applied in a prior PR. `npm audit --audit-level=high` exits 0.
- **Job B** (`Build Base Images (achaean-base-python)`): The `apt-get upgrade -y` step in `bases/Dockerfile.python` patches the trixie CVEs at build time. All base image jobs are green.

The current `main` failure (run `26587302254`, 2026-05-28) is `Build Vessel Images (achaean-worker)` — a new failure not in the original plan scope. Root cause: yq v4.53.2 (Go 1.26.2 embedded) triggers Trivy findings for 3 HIGH Go stdlib CVEs. Fix: `.trivyignore` suppression following the existing precedent for `gh` binary CVEs (PR #662, same Go 1.26.2 pattern).

## Verification

- `npm audit --audit-level=high && npx tsc --noEmit` in `dagger/` — exit 0 (confirmed locally).
- `.trivyignore` count: 30 entries (27 pre-existing + 3 new; all entries have valid 6-field headers).
- Existing base image, npm audit, and all other CI jobs remain unaffected.

## No .trivyignore changes other than the 3 new yq entries

No existing suppressions modified. All 27 pre-existing entries remain in place.

Closes #658

🤖 Generated with [Claude Code](https://claude.com/claude-code)