### PR TITLE
feat(security): externalize pip-audit aider-chat allowlist with expiry gate (#655)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ on:
       - 'justfile'
       - 'pixi.toml'
       - 'pixi.lock'
+      - '.pip-audit-ignore.aider-chat.txt'
   pull_request:
     branches: [main]
     paths:
@@ -33,6 +34,7 @@ on:
       - 'justfile'
       - 'pixi.toml'
       - 'pixi.lock'
+      - '.pip-audit-ignore.aider-chat.txt'
   schedule:
     - cron: '0 6 * * 1'  # Every Monday 06:00 UTC — digest freshness check
   workflow_dispatch:
@@ -243,10 +245,11 @@ jobs:
         working-directory: dagger
         run: npx tsc --noEmit
 
-      # The "Audit Python dependencies (aider-chat)" pip-audit step (with its
-      # 70+ --ignore-vuln allowlist for aider-chat's hard-pinned transitive
-      # CVEs) lived here and was removed when aider was disabled. Restore
-      # from PR #662 history if re-enabling aider — see #665 and #655.
+      # The "Audit Python dependencies (aider-chat)" pip-audit step lived here
+      # and was removed when the aider vessel was disabled — see #665 and #655.
+      # The 57-CVE allowlist is externalized in .pip-audit-ignore.aider-chat.txt
+      # (expires 2026-08-10). Restore the three CI gate steps from
+      # docs/runbooks/dependency-audit-allowlists.md when re-enabling aider.
 
   validate:
     name: Validate Compose Files

--- a/.pip-audit-ignore.aider-chat.txt
+++ b/.pip-audit-ignore.aider-chat.txt
@@ -1,0 +1,79 @@
+# pip-audit allowlist for aider-chat transitive dependencies
+#
+# 57 GHSA/PYSEC IDs covering aider-chat==0.82.3's hard-pinned dependency tree.
+# aider-chat pins each transitive dep with == so upgrades cannot land without a
+# new aider-chat release. All entries must be pruned once aider-chat releases
+# versions with fixed transitive deps.
+#
+# Expires: 2026-08-10
+#
+# Review procedure: see docs/runbooks/dependency-audit-allowlists.md
+# Issue: HomericIntelligence/AchaeanFleet#655
+# Cross-reference: .trivyignore also suppresses 1 overlapping ID (GHSA-69x8-hrgq-fjj8)
+#   for Trivy container scans. When removing an ID, search both files.
+#   See docs/runbooks/dependency-audit-allowlists.md for dual-file guidance.
+#
+# CI consumer: .github/workflows/ci.yml "Audit Python dependencies (aider-chat)" step.
+# NOTE: that step is currently disabled (aider vessel disabled in #665). Restore it
+# from PR #662 history when re-enabling aider, then this file will be consumed.
+#
+# GHSA/PYSEC IDs are lowercase per GitHub advisory database; CVE IDs uppercase.
+# Format regex: ^(GHSA-[0-9a-z-]+|PYSEC-[0-9]{4}-[0-9]+|CVE-[0-9]{4}-[0-9]+)$
+
+GHSA-2vrm-gr82-f7m5
+GHSA-2xpw-w6gg-jr37
+GHSA-38jv-5279-wg99
+GHSA-3wq7-rqq7-wx6j
+GHSA-48p4-8xcf-vxj5
+GHSA-4xh5-x5gv-qwph
+GHSA-5239-wwwm-4pmq
+GHSA-53mr-6c8q-9789
+GHSA-54jq-c3m8-4m76
+GHSA-58qw-9mgm-455v
+GHSA-5xmw-vc9v-4wf2
+GHSA-63hf-3vf5-4wqf
+GHSA-63vm-454h-vhhq
+GHSA-69f9-5gxw-wvc2
+GHSA-69x8-hrgq-fjj8
+GHSA-6jhg-hg63-jvvf
+GHSA-6mq8-rvhq-8wgg
+GHSA-6vgw-5pg2-w6jp
+GHSA-735f-pc8j-v9w8
+GHSA-7gcm-g887-7qv7
+GHSA-8qvm-5x2c-j2w7
+GHSA-9548-qrrj-x5pj
+GHSA-966j-vmvw-g2g9
+GHSA-9hjg-9r4m-mvj7
+GHSA-c427-h43c-vf67
+GHSA-cfh3-3jmp-rvhc
+GHSA-cx63-2mw6-8hw5
+GHSA-fh55-r93g-j68g
+GHSA-g84x-mcqj-x9qq
+GHSA-gc5v-m9x4-r6x2
+GHSA-gm62-xv2j-4w53
+GHSA-hcc4-c3v8-rx92
+GHSA-jj3x-wxrx-4x23
+GHSA-jjhc-v7c2-5hh6
+GHSA-jp4c-xjxw-mgf9
+GHSA-jr27-m4p2-rc6r
+GHSA-m5qp-6w8w-w647
+GHSA-mf9w-mj56-hr94
+GHSA-mqqc-3gqh-h2x8
+GHSA-mv93-w799-cj2w
+GHSA-mwh4-6h8g-pg8w
+GHSA-p998-jp59-783m
+GHSA-pq67-6m6q-mj2v
+GHSA-pwv6-vv43-88gr
+GHSA-qmgc-5h2g-mvrw
+GHSA-r73j-pqj5-w3x7
+GHSA-rpm5-65cw-6hj4
+GHSA-v87r-6q3f-2j67
+GHSA-w2fm-2cpv-w7v5
+GHSA-w853-jp5j-5j7f
+GHSA-w8v5-vhqr-4h9v
+GHSA-whj4-6x5x-4v2j
+GHSA-wjx4-4jcj-g98j
+GHSA-x2qx-6953-8485
+PYSEC-2022-43012
+PYSEC-2025-49
+PYSEC-2025-61

--- a/.trivyignore
+++ b/.trivyignore
@@ -80,6 +80,12 @@ CVE-2026-27904
 # Reviewer: @mvillmow  PR #TBD
 CVE-2026-23745
 
+# Cross-reference: .pip-audit-ignore.aider-chat.txt covers pip-audit findings for the same
+# aider-chat dependency tree (57 GHSA/PYSEC IDs). Trivy scans container image layers;
+# pip-audit scans Python wheel metadata. Dual suppression is intentional.
+# When removing an ID, search both files. See docs/runbooks/dependency-audit-allowlists.md.
+# Note: GHSA-69x8-hrgq-fjj8 below also appears in .pip-audit-ignore.aider-chat.txt.
+
 # CVE-2026-35030
 # Category: python
 # Rationale: litellm@1.68.0 CRITICAL auth bypass — fixed in 1.83.0, pinned (==) by aider-chat@0.82.3; no newer aider-chat release available as of 2026-04-29.

--- a/docs/runbooks/dependency-audit-allowlists.md
+++ b/docs/runbooks/dependency-audit-allowlists.md
@@ -1,0 +1,136 @@
+# Runbook: Dependency Audit Allowlists
+
+## Overview
+
+AchaeanFleet maintains two separate allowlist files for known-unfixable CVEs in the
+aider-chat transitive dependency tree:
+
+| File | Scanner | Scope |
+|---|---|---|
+| `.pip-audit-ignore.aider-chat.txt` | pip-audit | Python wheel metadata (aider-chat deps) |
+| `.trivyignore` | Trivy | Container image layers |
+
+**Dual suppression is intentional.** Trivy scans container image layers; pip-audit scans Python
+wheel metadata. The same CVE may appear in both tools via different detection paths. When removing
+an entry, search **both files**.
+
+## Background
+
+aider-chat==0.82.3 hard-pins all transitive dependencies with `==` constraints. This means 57
+known CVEs across 14 packages (aiohttp, diskcache, filelock, gitpython, litellm, pillow, pip,
+protobuf, pyasn1, pygments, python-dotenv, requests, setuptools, urllib3) cannot be resolved
+without a new aider-chat release. All 57 IDs are listed in `.pip-audit-ignore.aider-chat.txt`.
+
+See: HomericIntelligence/AchaeanFleet#655
+
+**Note:** The pip-audit CI step that consumes `.pip-audit-ignore.aider-chat.txt` is currently
+disabled because the aider vessel was disabled in #665. Restore the step from PR #662 history
+when re-enabling aider. The allowlist file is maintained here so it is ready on re-enablement.
+
+## Resolution Paths
+
+Pick one when unblocking the aider vessel:
+
+1. **Wait for upstream aider-chat to bump deps.** Track aider-chat release notes. Run the
+   re-audit procedure below after each new aider-chat release and prune resolved ignores.
+   Recommended if aider-chat is already pinned to the latest release.
+
+2. **Replace aider-chat** with a different agent backend if upstream is unresponsive on CVE
+   resolution. Remove `.pip-audit-ignore.aider-chat.txt` entirely once the replacement is in place.
+
+3. **Drop the audit step** if aider-chat's transitive tree is permanently downstream-uncontrollable.
+   The allowlist provides no security value if every CVE is indefinitely suppressed.
+
+## 2026-08-10 Review Checkpoint
+
+At review time, run:
+
+```bash
+# Install latest aider-chat in a clean venv
+python3 -m venv /tmp/aider-audit-venv
+source /tmp/aider-audit-venv/bin/activate
+pip install pip-audit aider-chat
+
+# Re-audit and compare against the allowlist
+pip-audit --desc 2>&1 | tee /tmp/pip-audit-fresh.txt
+
+# Check which allowlisted IDs are no longer present
+while IFS= read -r id; do
+  if ! grep -q "$id" /tmp/pip-audit-fresh.txt; then
+    echo "RESOLVED (remove from allowlist): $id"
+  fi
+done < <(grep -vE '^\s*(#|$)' .pip-audit-ignore.aider-chat.txt)
+
+deactivate
+rm -rf /tmp/aider-audit-venv /tmp/pip-audit-fresh.txt
+```
+
+After pruning resolved IDs:
+1. Remove each resolved ID from `.pip-audit-ignore.aider-chat.txt`.
+2. Search `.trivyignore` for each removed ID — remove from there too if present.
+3. Update the `# Expires:` header in `.pip-audit-ignore.aider-chat.txt` to the next review date
+   (90 days from now).
+4. Update the count assertion in the `Validate pip-audit allowlist format` CI step if the count
+   changed.
+5. Open a PR referencing #655.
+
+## Format Validation
+
+`.pip-audit-ignore.aider-chat.txt` must contain:
+- One CVE/GHSA/PYSEC ID per line.
+- Lines matching: `^(GHSA-[0-9a-z-]+|PYSEC-[0-9]{4}-[0-9]+|CVE-[0-9]{4}-[0-9]+)$`
+- Blank lines and `#` comment lines are ignored.
+- A `# Expires: YYYY-MM-DD` header with the next review date.
+
+GHSA and PYSEC IDs use lowercase hex (per GitHub advisory database convention).
+CVE IDs use uppercase.
+
+## Overlapping IDs
+
+One ID appears in both allowlist files: `GHSA-69x8-hrgq-fjj8` (litellm password hash exposure).
+Trivy detected this via image layer scan; pip-audit via wheel metadata. Both suppressions are
+intentional and should be removed together when litellm is upgraded past 1.83.0.
+
+## CI Steps (when aider is re-enabled)
+
+The three CI steps that consume `.pip-audit-ignore.aider-chat.txt` (from PR #662 history):
+
+```yaml
+- name: Validate pip-audit allowlist format
+  run: |
+    set -euo pipefail
+    file=".pip-audit-ignore.aider-chat.txt"
+    # GHSA/PYSEC IDs are lowercase per GitHub advisory database; CVE IDs uppercase.
+    bad=$(grep -vE '^\s*(#|$)' "$file" \
+      | grep -vE '^(GHSA-[0-9a-z-]+|PYSEC-[0-9]{4}-[0-9]+|CVE-[0-9]{4}-[0-9]+)$' || true)
+    if [[ -n "$bad" ]]; then
+      echo "ERROR: malformed entries in $file:"; echo "$bad"; exit 1
+    fi
+    count=$(grep -cvE '^\s*(#|$)' "$file")
+    echo "NOTE: allowlist count: $count. Update this assertion intentionally when count changes."
+
+- name: Check pip-audit allowlist expiry
+  run: |
+    set -euo pipefail
+    file=".pip-audit-ignore.aider-chat.txt"
+    today=$(date -u +%Y-%m-%d)
+    expired=0
+    while IFS= read -r line; do
+      if [[ "$line" =~ ^#\ Expires:\ ([0-9]{4}-[0-9]{2}-[0-9]{2})$ ]]; then
+        if [[ "${BASH_REMATCH[1]}" < "$today" ]]; then
+          echo "ERROR: pip-audit allowlist expired: ${BASH_REMATCH[1]}"; expired=1
+        fi
+      fi
+    done < "$file"
+    [[ $expired -eq 0 ]] || exit 1
+
+- name: Audit Python dependencies (aider-chat)
+  run: |
+    set -euo pipefail
+    pip install --quiet pip-audit aider-chat
+    # bash 5+ (GHA ubuntu-latest) — mapfile builtin required
+    mapfile -t ignores < <(grep -vE '^\s*(#|$)' .pip-audit-ignore.aider-chat.txt)
+    args=()
+    for id in "${ignores[@]}"; do args+=(--ignore-vuln "$id"); done
+    pip-audit --desc "${args[@]}"
+```


### PR DESCRIPTION
## Summary

- Creates `.pip-audit-ignore.aider-chat.txt` with 57 GHSA/PYSEC CVE IDs from aider-chat==0.82.3's hard-pinned transitive dependency tree, with `# Expires: 2026-08-10` header and runbook pointer
- Creates `docs/runbooks/dependency-audit-allowlists.md` documenting the dual-file relationship between `.pip-audit-ignore.aider-chat.txt` and `.trivyignore`, three resolution paths, and the 2026-08-10 review procedure including CI gate steps ready for when aider is re-enabled
- Updates the ci.yml tombstone comment (left by #665) to reference the new external allowlist file and runbook
- Adds `.pip-audit-ignore.aider-chat.txt` as a path trigger in both `on.push.paths` and `on.pull_request.paths` so allowlist edits trigger CI
- Adds a cross-reference header to `.trivyignore` above the aider-chat block noting the 1 overlapping ID (`GHSA-69x8-hrgq-fjj8`) and the dual-suppression rationale

## Divergence from plan

The plan's inline `--ignore-vuln` refactor cannot be implemented as written because the aider pip-audit CI step was removed when the aider vessel was disabled in #665 (tombstone comment at ci.yml:246-250 references #665 and #655). The plan assumed the step still existed. Instead this PR externalizes the allowlist file and runbook as the durable artifact — ready for consumption when #665 re-enables the aider vessel. The CI gate steps are documented verbatim in the runbook rather than added to ci.yml where they have no consumer.

## Verification

- `grep -cvE '^\s*(#|$)' .pip-audit-ignore.aider-chat.txt` → 57
- Format gate (bad entry injection) → exits non-zero
- Expiry gate (past date injection) → exits non-zero
- Expiry gate (2026-08-10) → exits zero against today 2026-05-29
- `mapfile` expansion → 57 `--ignore-vuln` args

Closes #655

🤖 Generated with [Claude Code](https://claude.com/claude-code)