### PR TITLE
docs(nomad): update PATTERNS.md §3 stale note — anti-pattern fixed in 34f2128 (#578)

### DIFF
--- a/nomad/PATTERNS.md
+++ b/nomad/PATTERNS.md
@@ -66,11 +66,11 @@ does **not** perform Consul Template interpolation. Using `${NOMAD_ALLOC_INDEX}`
 `env` block either produces the literal string `"claude-${NOMAD_ALLOC_INDEX}"` or fails
 silently depending on the Nomad version and task driver.
 
-> **Note:** `mesh.nomad.hcl` currently contains this anti-pattern in the `claude-agents`,
-> `aider-agents`, and `worker-agents` groups. It is tracked for correction in the Phase 6
-> rework (see issue #110 / #19). The 6 remaining Phase 6 vessel groups
-> (`codex-agents`, `gemini-agents`, `goose-agents`, `opencode-agents`, `q-agents`,
-> `agentcode-agents`) are tracked separately in issue #577.
+> **Note:** This anti-pattern previously existed in `mesh.nomad.hcl` across the `claude-agents`,
+> `aider-agents`, and `worker-agents` groups. It was corrected in commit 34f2128 (see issues
+> #110, #19, #578). All three groups now use `template` stanzas with Consul Template syntax
+> as shown in § 2 above. The 6 Phase 6 vessel groups (`codex-agents`, `gemini-agents`,
+> `goose-agents`, `opencode-agents`, `q-agents`, `agentcode-agents`) are tracked in issue #577.
 
 ---
 


### PR DESCRIPTION
## Summary

- The `${NOMAD_ALLOC_INDEX}` bare-env anti-pattern was already corrected in commit 34f2128 for `claude-agents`, `aider-agents`, and `worker-agents`.
- `nomad/PATTERNS.md` § 3 still contained a stale note claiming `mesh.nomad.hcl` "currently contains this anti-pattern" — a POLA violation for future readers.
- Replaced the stale "currently contains" note with a historical reference noting the fix, while preserving the issue #577 tracking reference for the 6 remaining Phase 6 vessel groups.
- No changes to `nomad/mesh.nomad.hcl` (already correct; issue #577 owns Phase 6 vessel groups).

## Divergence from plan

The plan described the note as spanning lines 69–71 but it actually spans lines 69–73 (five lines). The replacement preserves the issue #577 Phase 6 tracking reference that would have been silently dropped by the plan's proposed text — this matches the Plan Review comment's minor finding.

## Verification

- Grep for `\${NOMAD_ALLOC_INDEX}` in `mesh.nomad.hcl`: matches only appear in `service.name` stanzas (valid HCL context per § 4).
- No bare `env {}` stanza references `${NOMAD_ALLOC_INDEX}`.
- § 3 note now correctly describes the historical state.

Closes #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)