### PR TITLE
docs(github): add issue template config.yml and tighten PR checklist (#586)

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+---
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: >-
+      https://github.com/HomericIntelligence/AchaeanFleet/blob/main/SECURITY.md
+    about: >-
+      Please review our security policy before reporting vulnerabilities.
+  - name: Questions & discussions
+    url: >-
+      https://github.com/HomericIntelligence/AchaeanFleet/blob/main/CONTRIBUTING.md
+    about: >-
+      Read our contributing guide for questions about development workflow
+      and contribution process.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,3 +24,6 @@ Refs #ISSUE_NUMBER
 - [ ] Scope is focused (one logical change per PR)
 - [ ] No unrelated formatting / dependency churn
 - [ ] Documentation updated where behavior changed
+- [ ] Linked to a GitHub issue (Refs/Closes #N)
+- [ ] Conventional Commit format used (feat/fix/docs/chore/...)
+- [ ] `just verify` passes locally


### PR DESCRIPTION
## Summary

- Add `.github/ISSUE_TEMPLATE/config.yml` to disable blank issues (`blank_issues_enabled: false`) and provide `contact_links` for security disclosures (→ SECURITY.md) and contribution questions (→ CONTRIBUTING.md)
- Append three CONTRIBUTING.md-aligned checklist items to `.github/PULL_REQUEST_TEMPLATE.md`: linked issue (line 498), Conventional Commit format (line 180), and `just verify` gate (line 487)
- `bug_report.md` and `feature_request.md` are untouched — they already align with CONTRIBUTING.md's documented expectations

## Divergence from plan

No divergence. Existing templates confirmed present; `config.yml` was the only genuine gap. PR template checklist count confirmed 10 pre-edit → 13 post-edit (plan's ≥13 threshold verified).

## Verification

- `yamllint config.yml` exits 0
- `pre-commit run --files .github/ISSUE_TEMPLATE/config.yml .github/PULL_REQUEST_TEMPLATE.md` all hooks pass
- `grep -c '^- \[ \]' .github/PULL_REQUEST_TEMPLATE.md` returns 13

Closes #586

🤖 Generated with [Claude Code](https://claude.com/claude-code)