### PR TITLE
feat(ci): add runtime smoke tests for all 7 enabled AI-agent vessels (#580)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -878,6 +878,110 @@ jobs:
           fi
           echo "Read-only root smoke test: PASS"
 
+  test-smoke-vessels:
+    name: Smoke Test AI Vessel Entrypoint (${{ matrix.vessel.name }})
+    runs-on: ubuntu-latest
+    # Required check — add to branch protection required status checks in GitHub settings
+    strategy:
+      fail-fast: false
+      matrix:
+        vessel:
+          - name: achaean-claude
+            program: claude
+            version_flag: --version
+            base: achaean-base-node
+            base_dockerfile: bases/Dockerfile.node
+            dockerfile: vessels/claude/Dockerfile
+          - name: achaean-codex
+            program: codex
+            version_flag: --version
+            base: achaean-base-node
+            base_dockerfile: bases/Dockerfile.node
+            dockerfile: vessels/codex/Dockerfile
+          # achaean-aider disabled — see #665. Restore entry here when re-enabling.
+          - name: achaean-goose
+            program: goose
+            version_flag: --version
+            base: achaean-base-minimal
+            base_dockerfile: bases/Dockerfile.minimal
+            dockerfile: vessels/goose/Dockerfile
+          - name: achaean-cline
+            program: cline
+            version_flag: --version
+            base: achaean-base-node
+            base_dockerfile: bases/Dockerfile.node
+            dockerfile: vessels/cline/Dockerfile
+          - name: achaean-opencode
+            program: opencode
+            version_flag: --version
+            base: achaean-base-minimal
+            base_dockerfile: bases/Dockerfile.minimal
+            dockerfile: vessels/opencode/Dockerfile
+          - name: achaean-codebuff
+            program: codebuff
+            version_flag: --version
+            base: achaean-base-node
+            base_dockerfile: bases/Dockerfile.node
+            dockerfile: vessels/codebuff/Dockerfile
+          - name: achaean-ampcode
+            program: amp
+            version_flag: --version
+            base: achaean-base-node
+            base_dockerfile: bases/Dockerfile.node
+            dockerfile: vessels/ampcode/Dockerfile
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+
+      - name: Set up Docker Buildx (docker driver — loads image into daemon directly)
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
+        with:
+          driver: docker
+
+      - name: Build base image (${{ matrix.vessel.base }})
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: ${{ matrix.vessel.base_dockerfile }}
+          push: false
+          load: true
+          tags: ${{ matrix.vessel.base }}:latest
+
+      - name: Build vessel image (${{ matrix.vessel.name }})
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0
+        with:
+          context: .
+          file: ${{ matrix.vessel.dockerfile }}
+          build-args: |
+            BASE_IMAGE=${{ matrix.vessel.base }}:latest
+            GOOSE_VERSION=1.31.1
+            YQ_VERSION=v4.53.2
+            OPENCODE_VERSION=v1.4.3
+          push: false
+          load: true
+          tags: ${{ matrix.vessel.name }}:latest
+
+      - name: Smoke test — binary reachable and invokable via entrypoint
+        # Exercises entrypoint.sh (exec "$@" path) end-to-end WITHOUT --entrypoint=""
+        # so that errors in entrypoint.sh itself are caught.  --version proves the
+        # binary is on PATH and its shared libraries load correctly.
+        # Matrix values are static workflow constants (not user-supplied inputs), but
+        # we bind them through env vars as best practice for all run: interpolations.
+        env:
+          VESSEL_IMAGE: ${{ matrix.vessel.name }}:latest
+          VESSEL_PROGRAM: ${{ matrix.vessel.program }}
+          VESSEL_VERSION_FLAG: ${{ matrix.vessel.version_flag }}
+        run: |
+          timeout 30 docker run --rm \
+            --read-only \
+            --tmpfs /tmp \
+            --tmpfs /run \
+            --tmpfs /home/agent/.cache \
+            --tmpfs /home/agent/.config \
+            --tmpfs /home/agent/.local \
+            "$VESSEL_IMAGE" \
+            "$VESSEL_PROGRAM" "$VESSEL_VERSION_FLAG"
+          echo "Entrypoint smoke test passed: $VESSEL_PROGRAM $VESSEL_VERSION_FLAG"
+
   build-goose-multiarch:
     name: Build Goose Vessel (Multi-Arch)
     runs-on: ubuntu-24.04

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,10 +176,14 @@ HEALTHCHECK --interval=10s --timeout=3s --start-period=10s --retries=3 \
 
 AI-agent vessels (`claude`, `codex`, `aider`, `goose`, `cline`, `opencode`,
 `codebuff`, `ampcode`) **do not declare a Dockerfile `CMD`**. They inherit
-`ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]` from the base image, and
-`bases/entrypoint.sh` dispatches to `$AGENT_PROGRAM` (set per-vessel via
-`ENV AGENT_PROGRAM=<binary>`) with `$AGENT_HEADLESS_FLAG` appended. This
-keeps the launch contract uniform across vessels.
+`ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]` from the base image.
+
+**Important:** `bases/entrypoint.sh` does **not** dispatch to `$AGENT_PROGRAM`.
+It runs `exec "$@"` — it hands off to whatever arguments are passed to
+`docker run` (or `CMD` if present). The `$AGENT_PROGRAM` env var names the
+AI binary installed inside the vessel; it is used by the runtime sidecar
+(ProjectAgamemnon) or passed explicitly as `docker run <vessel> <binary> <args>`.
+Do not write plans assuming `entrypoint.sh` auto-launches `$AGENT_PROGRAM`.
 
 The **only** vessel that overrides this is `worker`, which has no AI binary
 to run and instead serves the healthcheck endpoint directly:
@@ -189,7 +193,8 @@ CMD ["node", "/app/healthcheck-server.js"]
 ```
 
 When adding a new agent vessel, set `ENV AGENT_PROGRAM=...` (and optionally
-`ENV AGENT_HEADLESS_FLAG=...`) — do **not** add a `CMD`.
+`ENV AGENT_HEADLESS_FLAG=...`) — do **not** add a `CMD`. The runtime sidecar
+will supply the command at container start time.
 
 ## Nomad
 

--- a/tests/test_smoke_matrix_drift.py
+++ b/tests/test_smoke_matrix_drift.py
@@ -1,0 +1,189 @@
+"""
+Drift guard: assert every enabled AI-agent vessel directory is represented in
+the ``test-smoke-vessels`` matrix in ``.github/workflows/ci.yml``.
+
+Prevents new vessels from silently bypassing runtime smoke coverage.
+
+Design notes
+------------
+- Uses ``yaml.safe_load`` (pyyaml ≥6, available via pixi.lock).
+- Fails loudly if the workflow file, the job, or the matrix key is absent —
+  a silent pass on a missing structure would defeat the purpose.
+- ``worker`` is excluded: it has its own HTTP health-poll smoke test
+  (``test-smoke`` job).
+- ``aider`` is excluded: currently disabled in CI — see issue #665.  When
+  aider is re-enabled, remove it from ``DISABLED_VESSELS`` and add the
+  matrix row in ci.yml; this test will then enforce coverage automatically.
+
+Run locally:
+    pixi run pytest tests/test_smoke_matrix_drift.py -v
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).parent.parent
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+SMOKE_JOB_NAME = "test-smoke-vessels"
+
+# Vessels excluded from the smoke matrix intentionally:
+#   worker      — has a dedicated HTTP /health smoke job (test-smoke)
+#   aider       — disabled in CI per #665; re-enable there first
+#   hello-world — C++ E2E integration test binary, not an AI-agent vessel;
+#                 it has its own CMD and is not part of the agent mesh smoke set
+EXCLUDED_VESSELS = {"worker", "aider", "hello-world"}
+
+
+def _load_workflow() -> dict:
+    """Load ci.yml and raise an informative error if it is missing or malformed."""
+    if not CI_WORKFLOW.exists():
+        pytest.fail(
+            f"Workflow file not found: {CI_WORKFLOW}. "
+            "This test cannot guard drift without it."
+        )
+    raw = CI_WORKFLOW.read_text(encoding="utf-8")
+    data = yaml.safe_load(raw)
+    if not isinstance(data, dict):
+        pytest.fail(
+            f"Unexpected top-level type in {CI_WORKFLOW}: {type(data).__name__}. "
+            "Expected a YAML mapping."
+        )
+    return data
+
+
+def _get_smoke_matrix_vessels(workflow: dict) -> list[str]:
+    """
+    Extract the list of vessel ``name`` values from the test-smoke-vessels matrix.
+
+    Raises pytest.fail (not KeyError/AttributeError) so the test output is clear.
+    """
+    jobs = workflow.get("jobs")
+    if not isinstance(jobs, dict):
+        pytest.fail(
+            f"'jobs' key missing or not a mapping in {CI_WORKFLOW}. "
+            "Cannot locate the smoke matrix."
+        )
+
+    job = jobs.get(SMOKE_JOB_NAME)
+    if job is None:
+        pytest.fail(
+            f"Job '{SMOKE_JOB_NAME}' not found in {CI_WORKFLOW}. "
+            "Add the job or update SMOKE_JOB_NAME in this test."
+        )
+
+    strategy = job.get("strategy")
+    if not isinstance(strategy, dict):
+        pytest.fail(
+            f"Job '{SMOKE_JOB_NAME}' has no 'strategy' key in {CI_WORKFLOW}. "
+            "The matrix job must have a strategy.matrix.vessel list."
+        )
+
+    matrix = strategy.get("matrix")
+    if not isinstance(matrix, dict):
+        pytest.fail(
+            f"Job '{SMOKE_JOB_NAME}' strategy has no 'matrix' key in {CI_WORKFLOW}."
+        )
+
+    vessel_rows = matrix.get("vessel")
+    if not isinstance(vessel_rows, list) or len(vessel_rows) == 0:
+        pytest.fail(
+            f"Job '{SMOKE_JOB_NAME}' matrix.vessel is missing or empty in {CI_WORKFLOW}. "
+            "Expected a list of vessel objects each with a 'name' field."
+        )
+
+    names: list[str] = []
+    for row in vessel_rows:
+        if not isinstance(row, dict) or "name" not in row:
+            pytest.fail(
+                f"Malformed matrix row in '{SMOKE_JOB_NAME}': {row!r}. "
+                "Each row must be a mapping with at least a 'name' key."
+            )
+        names.append(row["name"])
+    return names
+
+
+def _vessel_dirs() -> list[str]:
+    """Return vessel directory names (stems) under vessels/, excluding disabled ones."""
+    vessels_path = REPO_ROOT / "vessels"
+    if not vessels_path.is_dir():
+        pytest.fail(f"vessels/ directory not found at {vessels_path}")
+    return [
+        d.name
+        for d in sorted(vessels_path.iterdir())
+        if d.is_dir() and d.name not in EXCLUDED_VESSELS
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_all_vessels_have_smoke_matrix_entry() -> None:
+    """Every enabled vessel directory must appear in the test-smoke-vessels matrix."""
+    workflow = _load_workflow()
+    matrix_names = _get_smoke_matrix_vessels(workflow)
+
+    # Strip the 'achaean-' prefix from matrix names to get the vessel slug
+    # (e.g. 'achaean-claude' → 'claude') so we can compare with directory names.
+    matrix_slugs = set()
+    for name in matrix_names:
+        if name.startswith("achaean-"):
+            matrix_slugs.add(name[len("achaean-"):])
+        else:
+            matrix_slugs.add(name)
+
+    vessel_dirs = _vessel_dirs()
+    missing = [v for v in vessel_dirs if v not in matrix_slugs]
+
+    assert not missing, (
+        f"The following vessel directories are NOT in the '{SMOKE_JOB_NAME}' matrix:\n"
+        + "\n".join(f"  vessels/{v}" for v in missing)
+        + "\n\nAdd them to the matrix in .github/workflows/ci.yml, or add them to "
+        "EXCLUDED_VESSELS in this test if they are intentionally excluded."
+    )
+
+
+def test_no_phantom_matrix_entries() -> None:
+    """Every matrix entry must correspond to an existing vessel directory."""
+    workflow = _load_workflow()
+    matrix_names = _get_smoke_matrix_vessels(workflow)
+
+    vessels_path = REPO_ROOT / "vessels"
+    existing_dirs = {d.name for d in vessels_path.iterdir() if d.is_dir()}
+
+    phantoms: list[str] = []
+    for name in matrix_names:
+        slug = name[len("achaean-"):] if name.startswith("achaean-") else name
+        if slug not in existing_dirs:
+            phantoms.append(name)
+
+    assert not phantoms, (
+        f"The following matrix entries in '{SMOKE_JOB_NAME}' have no matching "
+        "vessel directory:\n"
+        + "\n".join(f"  {n}" for n in phantoms)
+        + "\n\nRemove the stale matrix entries from .github/workflows/ci.yml."
+    )
+
+
+def test_matrix_rows_have_required_fields() -> None:
+    """Each matrix row must define name, program, version_flag, base, and dockerfile."""
+    workflow = _load_workflow()
+    strategy = workflow["jobs"][SMOKE_JOB_NAME]["strategy"]
+    vessel_rows = strategy["matrix"]["vessel"]
+
+    required_fields = {"name", "program", "version_flag", "base", "dockerfile"}
+    incomplete: list[str] = []
+    for row in vessel_rows:
+        missing_fields = required_fields - set(row.keys())
+        if missing_fields:
+            incomplete.append(f"{row.get('name', '<unknown>')}: missing {missing_fields}")
+
+    assert not incomplete, (
+        f"Incomplete matrix rows in '{SMOKE_JOB_NAME}':\n"
+        + "\n".join(f"  {m}" for m in incomplete)
+    )


### PR DESCRIPTION
## Summary

- **New CI job `test-smoke-vessels`**: matrix of 7 enabled AI-agent vessels (claude, codex, goose, cline, opencode, codebuff, ampcode), each built fresh and run via `docker run --rm --read-only <tmpfs mounts> <vessel> <binary> --version`. The `docker run` command deliberately omits `--entrypoint=""` so `bases/entrypoint.sh` is exercised end-to-end. Aider excluded per #665; worker covered by existing `test-smoke` HTTP job. Matrix values bound through `env:` variables in `run:` steps per GHA injection-safety best practice.
- **New drift guard `tests/test_smoke_matrix_drift.py`**: 3 pytest assertions that every enabled vessel directory is in the matrix, no phantom entries exist, and all rows have required fields (`name`, `program`, `version_flag`, `base`, `dockerfile`). Uses pyyaml (available in pixi.lock). Fails loudly if the job or matrix structure is absent. 202 tests pass.
- **CLAUDE.md fix**: correct the false "Vessel CMD pattern" claim that `entrypoint.sh` dispatches to `$AGENT_PROGRAM`; document the actual `exec "$@"` behaviour and that the sidecar supplies the command at runtime. Prevents future plans from being built on the same false premise.

## Divergences from plan noted for PR body

- Plan's "bash case for base selection" replaced with explicit `base` + `base_dockerfile` matrix columns, matching the existing `build-vessels` pattern (cleaner, per plan reviewer's recommendation).
- `aider` excluded from matrix to match `build-vessels` (per plan reviewer's concrete blocker finding); see #665 for re-enable path.
- `hello-world` vessel excluded from drift guard (C++ E2E binary, not in `build-vessels` matrix, not an AI-agent vessel).
- All matrix-value interpolations in `run:` moved to `env:` vars for GHA injection-safety best practice.

## Test plan

- [x] `pixi run pytest tests/test_smoke_matrix_drift.py -v` -- 3 passed
- [x] `pixi run pytest` -- 202 passed
- [x] `yamllint -c .yamllint.yml .github/workflows/ci.yml` -- only pre-existing warning at line 246, no errors in new code
- [x] Negative test (manual): removing `achaean-claude` from matrix causes drift guard to report `vessels/claude` missing
- [ ] CI: `test-smoke-vessels` matrix shows 7 green jobs; `test-smoke` (worker HTTP) stays green

Closes #580

🤖 Generated with [Claude Code](https://claude.com/claude-code)