### PR TITLE
feat(nomad): add 6 missing vessel groups to mesh.nomad.hcl (#577)

### DIFF
--- a/nomad/PATTERNS.md
+++ b/nomad/PATTERNS.md
@@ -69,8 +69,9 @@ silently depending on the Nomad version and task driver.
 > **Note:** This anti-pattern previously existed in `mesh.nomad.hcl` across the `claude-agents`,
 > `aider-agents`, and `worker-agents` groups. It was corrected in commit 34f2128 (see issues
 > #110, #19, #578). All three groups now use `template` stanzas with Consul Template syntax
-> as shown in § 2 above. The 6 Phase 6 vessel groups (`codex-agents`, `gemini-agents`,
-> `goose-agents`, `opencode-agents`, `q-agents`, `agentcode-agents`) are tracked in issue #577.
+> as shown in § 2 above. The 6 additional vessel groups (`codex-agents`, `goose-agents`,
+> `cline-agents`, `opencode-agents`, `codebuff-agents`, `ampcode-agents`) were added in
+> issue #577 and follow the same established `template`-stanza pattern.
 
 ---
 

--- a/nomad/mesh.nomad.hcl
+++ b/nomad/mesh.nomad.hcl
@@ -225,6 +225,378 @@ EOH
   }
 
   # -------------------------------------------------------------------------
+  # Codex agents group
+  # -------------------------------------------------------------------------
+  group "codex-agents" {
+    count = 1
+
+    network {
+      port "agent" { to = 23001 }
+    }
+
+    task "codex" {
+      driver = "docker"
+
+      config {
+        image        = "achaean-codex:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
+        volumes = [
+          "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
+        ]
+      }
+
+      env {
+        AGENT_PORT    = "23001"
+        AGAMEMNON_URL = var.agamemnon_url
+      }
+
+      # NOMAD_ALLOC_INDEX is only available via Consul Template — see nomad/PATTERNS.md
+      template {
+        data        = <<EOT
+TMUX_SESSION_NAME="codex-{{ env "NOMAD_ALLOC_INDEX" }}"
+AGENT_ID="codex-{{ env "NOMAD_ALLOC_INDEX" }}"
+EOT
+        destination = "local/runtime-env.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 2000  # MHz
+        memory = 4096  # MB
+      }
+      logs {
+        max_files     = 3
+        max_file_size = 10
+      }
+
+      service {
+        name = "achaean-codex-${NOMAD_ALLOC_INDEX}"
+        port = "agent"
+
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+    }
+  }
+
+  # -------------------------------------------------------------------------
+  # Goose agents group
+  # -------------------------------------------------------------------------
+  group "goose-agents" {
+    count = 1
+
+    network {
+      port "agent" { to = 23001 }
+    }
+
+    task "goose" {
+      driver = "docker"
+
+      config {
+        image        = "achaean-goose:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
+        volumes = [
+          "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
+        ]
+      }
+
+      env {
+        AGENT_PORT    = "23001"
+        AGAMEMNON_URL = var.agamemnon_url
+      }
+
+      # NOMAD_ALLOC_INDEX is only available via Consul Template — see nomad/PATTERNS.md
+      template {
+        data        = <<EOT
+TMUX_SESSION_NAME="goose-{{ env "NOMAD_ALLOC_INDEX" }}"
+AGENT_ID="goose-{{ env "NOMAD_ALLOC_INDEX" }}"
+EOT
+        destination = "local/runtime-env.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 2000  # MHz
+        memory = 4096  # MB
+      }
+      logs {
+        max_files     = 3
+        max_file_size = 10
+      }
+
+      service {
+        name = "achaean-goose-${NOMAD_ALLOC_INDEX}"
+        port = "agent"
+
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+    }
+  }
+
+  # -------------------------------------------------------------------------
+  # Cline agents group
+  # -------------------------------------------------------------------------
+  group "cline-agents" {
+    count = 1
+
+    network {
+      port "agent" { to = 23001 }
+    }
+
+    task "cline" {
+      driver = "docker"
+
+      config {
+        image        = "achaean-cline:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
+        volumes = [
+          "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
+        ]
+      }
+
+      env {
+        AGENT_PORT    = "23001"
+        AGAMEMNON_URL = var.agamemnon_url
+      }
+
+      # NOMAD_ALLOC_INDEX is only available via Consul Template — see nomad/PATTERNS.md
+      template {
+        data        = <<EOT
+TMUX_SESSION_NAME="cline-{{ env "NOMAD_ALLOC_INDEX" }}"
+AGENT_ID="cline-{{ env "NOMAD_ALLOC_INDEX" }}"
+EOT
+        destination = "local/runtime-env.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 2000  # MHz
+        memory = 4096  # MB
+      }
+      logs {
+        max_files     = 3
+        max_file_size = 10
+      }
+
+      service {
+        name = "achaean-cline-${NOMAD_ALLOC_INDEX}"
+        port = "agent"
+
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+    }
+  }
+
+  # -------------------------------------------------------------------------
+  # OpenCode agents group
+  # -------------------------------------------------------------------------
+  group "opencode-agents" {
+    count = 1
+
+    network {
+      port "agent" { to = 23001 }
+    }
+
+    task "opencode" {
+      driver = "docker"
+
+      config {
+        image        = "achaean-opencode:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
+        volumes = [
+          "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
+        ]
+      }
+
+      env {
+        AGENT_PORT    = "23001"
+        AGAMEMNON_URL = var.agamemnon_url
+      }
+
+      # NOMAD_ALLOC_INDEX is only available via Consul Template — see nomad/PATTERNS.md
+      template {
+        data        = <<EOT
+TMUX_SESSION_NAME="opencode-{{ env "NOMAD_ALLOC_INDEX" }}"
+AGENT_ID="opencode-{{ env "NOMAD_ALLOC_INDEX" }}"
+EOT
+        destination = "local/runtime-env.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 2000  # MHz
+        memory = 4096  # MB
+      }
+      logs {
+        max_files     = 3
+        max_file_size = 10
+      }
+
+      service {
+        name = "achaean-opencode-${NOMAD_ALLOC_INDEX}"
+        port = "agent"
+
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+    }
+  }
+
+  # -------------------------------------------------------------------------
+  # Codebuff agents group
+  # -------------------------------------------------------------------------
+  group "codebuff-agents" {
+    count = 1
+
+    network {
+      port "agent" { to = 23001 }
+    }
+
+    task "codebuff" {
+      driver = "docker"
+
+      config {
+        image        = "achaean-codebuff:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
+        volumes = [
+          "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
+        ]
+      }
+
+      env {
+        AGENT_PORT    = "23001"
+        AGAMEMNON_URL = var.agamemnon_url
+      }
+
+      # NOMAD_ALLOC_INDEX is only available via Consul Template — see nomad/PATTERNS.md
+      template {
+        data        = <<EOT
+TMUX_SESSION_NAME="codebuff-{{ env "NOMAD_ALLOC_INDEX" }}"
+AGENT_ID="codebuff-{{ env "NOMAD_ALLOC_INDEX" }}"
+EOT
+        destination = "local/runtime-env.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 2000  # MHz
+        memory = 4096  # MB
+      }
+      logs {
+        max_files     = 3
+        max_file_size = 10
+      }
+
+      service {
+        name = "achaean-codebuff-${NOMAD_ALLOC_INDEX}"
+        port = "agent"
+
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+    }
+  }
+
+  # -------------------------------------------------------------------------
+  # AmpCode agents group
+  # -------------------------------------------------------------------------
+  group "ampcode-agents" {
+    count = 1
+
+    network {
+      port "agent" { to = 23001 }
+    }
+
+    task "ampcode" {
+      driver = "docker"
+
+      config {
+        image        = "achaean-ampcode:latest"
+        ports        = ["agent"]
+        cap_drop     = ["ALL"]
+        no_new_privs = true
+        volumes = [
+          "${var.agamemnon_sidecar_path}:/app/agent-sidecar:ro",
+          "${var.tls_cert_dir}:/certs:ro",
+        ]
+      }
+
+      env {
+        AGENT_PORT    = "23001"
+        AGAMEMNON_URL = var.agamemnon_url
+      }
+
+      # NOMAD_ALLOC_INDEX is only available via Consul Template — see nomad/PATTERNS.md
+      template {
+        data        = <<EOT
+TMUX_SESSION_NAME="ampcode-{{ env "NOMAD_ALLOC_INDEX" }}"
+AGENT_ID="ampcode-{{ env "NOMAD_ALLOC_INDEX" }}"
+EOT
+        destination = "local/runtime-env.env"
+        env         = true
+      }
+
+      resources {
+        cpu    = 2000  # MHz
+        memory = 4096  # MB
+      }
+      logs {
+        max_files     = 3
+        max_file_size = 10
+      }
+
+      service {
+        name = "achaean-ampcode-${NOMAD_ALLOC_INDEX}"
+        port = "agent"
+
+        check {
+          type     = "http"
+          path     = "/health"
+          interval = "30s"
+          timeout  = "5s"
+        }
+      }
+    }
+  }
+
+  # -------------------------------------------------------------------------
   # Shell Worker group
   # -------------------------------------------------------------------------
   group "worker-agents" {

--- a/tests/test_nomad_mesh_spec.py
+++ b/tests/test_nomad_mesh_spec.py
@@ -1,0 +1,207 @@
+"""Regression tests for nomad/mesh.nomad.hcl vessel group completeness.
+
+Validates that all 9 expected vessel groups are present and correctly configured:
+- All 9 group names are present
+- Each group has exactly one task block with the correct image name
+- Each group declares port "agent" { to = 23001 }
+- Each group has a service check with path = "/health"
+- Each task has agamemnon_sidecar_path and tls_cert_dir volume mounts (:ro)
+- Each task sets AGENT_PORT = "23001" and AGAMEMNON_URL = var.agamemnon_url
+- Pure text/regex assertions — no nomad binary required
+"""
+
+import re
+from pathlib import Path
+
+NOMAD_JOB = Path(__file__).parent.parent / "nomad" / "mesh.nomad.hcl"
+
+EXPECTED_GROUPS = [
+    "claude-agents",
+    "aider-agents",
+    "codex-agents",
+    "goose-agents",
+    "cline-agents",
+    "opencode-agents",
+    "codebuff-agents",
+    "ampcode-agents",
+    "worker-agents",
+]
+
+# Groups whose task image name differs from the group base name
+IMAGE_OVERRIDES: dict[str, str] = {}
+
+# Groups that do not follow the standard achaean-<name>:latest image pattern
+# (worker uses a separate image, claude/aider are also standard)
+
+
+def _text() -> str:
+    return NOMAD_JOB.read_text()
+
+
+def _group_base(group_name: str) -> str:
+    """Return the agent name portion from a group name (strip '-agents' suffix)."""
+    return group_name.removesuffix("-agents")
+
+
+def test_all_nine_groups_present() -> None:
+    """All 9 expected vessel groups must be declared in mesh.nomad.hcl."""
+    text = _text()
+    for group in EXPECTED_GROUPS:
+        assert f'group "{group}"' in text, (
+            f'Group "{group}" is missing from nomad/mesh.nomad.hcl. '
+            f"Expected 9 groups; found only: "
+            + str([g for g in EXPECTED_GROUPS if f'group "{g}"' in text])
+        )
+
+
+def test_nine_groups_total() -> None:
+    """Exactly 9 active (non-commented) vessel groups must be present."""
+    text = _text()
+    # Match only non-commented group lines
+    active_groups = re.findall(r'^\s+group\s+"[a-z]+-agents"', text, re.MULTILINE)
+    assert len(active_groups) == 9, (
+        f"Expected 9 active group blocks, found {len(active_groups)}: {active_groups}"
+    )
+
+
+def test_each_group_has_correct_image() -> None:
+    """Each vessel group must declare the correct achaean-<name>:latest image."""
+    text = _text()
+    for group in EXPECTED_GROUPS:
+        name = _group_base(group)
+        image = IMAGE_OVERRIDES.get(group, f"achaean-{name}:latest")
+        assert f'image        = "{image}"' in text or f'image = "{image}"' in text, (
+            f'Group "{group}" must declare image = "{image}" in its task config'
+        )
+
+
+def test_each_group_declares_agent_port_23001() -> None:
+    """Every group's network block must declare port 'agent' mapped to container 23001."""
+    text = _text()
+    # The pattern appears once per group (except worker which also has it)
+    port_declarations = re.findall(r'port\s+"agent"\s*\{\s*to\s*=\s*23001\s*\}', text)
+    # We expect at least 9 (one per group; claude-agents uses the multi-line form)
+    # claude-agents uses multi-line form with comment — check separately
+    multiline_port = re.findall(
+        r'port\s+"agent"\s*\{[^}]*to\s*=\s*23001[^}]*\}', text, re.DOTALL
+    )
+    assert len(multiline_port) == 9, (
+        f"Expected 9 port 'agent' {{ to = 23001 }} declarations (one per group), "
+        f"found {len(multiline_port)}"
+    )
+
+
+def test_each_group_has_agent_port_env() -> None:
+    """Every task must set AGENT_PORT = '23001' in its env stanza."""
+    text = _text()
+    occurrences = text.count('AGENT_PORT    = "23001"') + text.count('AGENT_PORT  = "23001"') + text.count('AGENT_PORT = "23001"')
+    assert occurrences >= 9, (
+        f"Expected at least 9 AGENT_PORT = \"23001\" env declarations (one per group), "
+        f"found {occurrences}"
+    )
+
+
+def test_each_group_has_agamemnon_url_env() -> None:
+    """Every task must reference var.agamemnon_url for AGAMEMNON_URL."""
+    text = _text()
+    occurrences = text.count("AGAMEMNON_URL = var.agamemnon_url")
+    assert occurrences >= 9, (
+        f"Expected at least 9 AGAMEMNON_URL = var.agamemnon_url declarations, "
+        f"found {occurrences}"
+    )
+
+
+def test_each_group_has_health_check_path() -> None:
+    """Every group's service check must use path = '/health'."""
+    text = _text()
+    health_checks = re.findall(r'path\s*=\s*"/health"', text)
+    assert len(health_checks) >= 9, (
+        f"Expected at least 9 path = \"/health\" service check declarations, "
+        f"found {len(health_checks)}"
+    )
+
+
+def test_each_group_has_agamemnon_sidecar_volume() -> None:
+    """Every task must mount the agamemnon sidecar binary read-only."""
+    text = _text()
+    # Pattern: agamemnon_sidecar_path}:/app/agent-sidecar:ro
+    sidecar_mounts = re.findall(
+        r'agamemnon_sidecar_path\}:/app/agent-sidecar:ro', text
+    )
+    assert len(sidecar_mounts) >= 9, (
+        f"Expected at least 9 agamemnon sidecar :ro volume mounts (one per group), "
+        f"found {len(sidecar_mounts)}"
+    )
+
+
+def test_each_group_has_tls_cert_volume() -> None:
+    """Every task must mount the TLS cert directory read-only."""
+    text = _text()
+    cert_mounts = re.findall(r'tls_cert_dir\}:/certs:ro', text)
+    assert len(cert_mounts) >= 9, (
+        f"Expected at least 9 tls_cert_dir :ro volume mounts (one per group), "
+        f"found {len(cert_mounts)}"
+    )
+
+
+def test_new_groups_have_cap_drop_all() -> None:
+    """The 6 new groups must enforce cap_drop = ['ALL'] for security hardening."""
+    text = _text()
+    new_groups = [
+        "codex-agents",
+        "goose-agents",
+        "cline-agents",
+        "opencode-agents",
+        "codebuff-agents",
+        "ampcode-agents",
+    ]
+    cap_drop_count = len(re.findall(r'cap_drop\s*=\s*\["ALL"\]', text))
+    # All 9 groups should have cap_drop (3 existing + 6 new)
+    assert cap_drop_count >= 9, (
+        f"Expected at least 9 cap_drop = [\"ALL\"] declarations, found {cap_drop_count}. "
+        f"All groups including the 6 new ones ({new_groups}) must enforce cap_drop."
+    )
+
+
+def test_new_groups_have_no_new_privs() -> None:
+    """All groups must set no_new_privs = true for security hardening."""
+    text = _text()
+    no_new_privs_count = len(re.findall(r'no_new_privs\s*=\s*true', text))
+    assert no_new_privs_count >= 9, (
+        f"Expected at least 9 no_new_privs = true declarations, found {no_new_privs_count}"
+    )
+
+
+def test_six_new_groups_have_count_1() -> None:
+    """The 6 new vessel groups must each have count = 1 (matching compose parity)."""
+    text = _text()
+    for group in [
+        "codex-agents",
+        "goose-agents",
+        "cline-agents",
+        "opencode-agents",
+        "codebuff-agents",
+        "ampcode-agents",
+    ]:
+        # Find the group block and check that count = 1 appears before the next group
+        # Use a regex to extract the group block content
+        pattern = re.compile(
+            rf'group\s+"{re.escape(group)}"\s*\{{.*?(?=group\s+"|\Z)',
+            re.DOTALL,
+        )
+        match = pattern.search(text)
+        assert match, f'Could not locate group block for "{group}"'
+        block = match.group(0)
+        assert re.search(r'count\s*=\s*1\b', block), (
+            f'Group "{group}" must have count = 1 (matches compose: exactly one instance)'
+        )
+
+
+def test_new_groups_service_naming_convention() -> None:
+    """Each new group's service name must follow achaean-<name>-${NOMAD_ALLOC_INDEX}."""
+    text = _text()
+    for name in ["codex", "goose", "cline", "opencode", "codebuff", "ampcode"]:
+        expected = f'name = "achaean-{name}-${{NOMAD_ALLOC_INDEX}}"'
+        assert expected in text, (
+            f'Service name for {name}-agents must be "{expected}"; not found in HCL'
+        )


### PR DESCRIPTION
## Summary

- Adds 6 missing vessel groups (`codex-agents`, `goose-agents`, `cline-agents`, `opencode-agents`, `codebuff-agents`, `ampcode-agents`) to `nomad/mesh.nomad.hcl`, bringing the total active Nomad groups from 3 to 9 — full parity with `compose/docker-compose.mesh.yml`
- Each new group mirrors the established `aider-agents` pattern: `count=1`, `port "agent" { to=23001 }`, `cap_drop=["ALL"]`, `no_new_privs=true`, read-only sidecar and cert volume mounts, static `AGENT_PORT`/`AGAMEMNON_URL` env vars, and Consul Template stanzas for `AGENT_ID`/`TMUX_SESSION_NAME`
- Adds `tests/test_nomad_mesh_spec.py` with 13 regression assertions covering all groups: names, image names, port declarations (`to=23001`), health check paths (`/health`), volume mounts (`:ro`), env vars, security hardening, `count=1` for new groups, and service naming convention
- Updates `nomad/PATTERNS.md` §3 to reflect that issue #577 is resolved (removes stale tracking reference)

## Divergence from plan noted

The plan's §4 noted that `OPENAI_API_KEY` is absent from the new group env stanzas. This is intentional and consistent with the pre-existing `aider-agents` pattern — secrets (including OpenAI keys) are managed via Vault (PATTERNS.md §5) rather than inline env vars. The plan explicitly scoped this out as consistent with existing HCL behavior.

PATTERNS.md listed different group names (`gemini-agents`, `q-agents`, `agentcode-agents`) vs. the issue's actual names (`cline-agents`, `codebuff-agents`, `ampcode-agents`). The implementation follows the issue body and compose file — the compose service names are authoritative.

## Verification

- `pytest tests/test_nomad_mesh_spec.py -v` — 13/13 passed
- `pytest tests/` — 205/205 passed (zero regressions)
- `grep -E 'group "[a-z]+-agents"' nomad/mesh.nomad.hcl | wc -l` returns 9

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)