### PR TITLE
fix(ci): docker-container buildx driver + MD032 in audit runbook

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,10 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
 
-      - name: Set up Docker Buildx (docker driver)
+      - name: Set up Docker Buildx (docker-container driver)
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
         with:
-          driver: docker
+          driver: docker-container
 
       - name: Build achaean-base-node
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0

--- a/docs/runbooks/dependency-audit-allowlists.md
+++ b/docs/runbooks/dependency-audit-allowlists.md
@@ -66,6 +66,7 @@ rm -rf /tmp/aider-audit-venv /tmp/pip-audit-fresh.txt
 ```
 
 After pruning resolved IDs:
+
 1. Remove each resolved ID from `.pip-audit-ignore.aider-chat.txt`.
 2. Search `.trivyignore` for each removed ID — remove from there too if present.
 3. Update the `# Expires:` header in `.pip-audit-ignore.aider-chat.txt` to the next review date
@@ -77,6 +78,7 @@ After pruning resolved IDs:
 ## Format Validation
 
 `.pip-audit-ignore.aider-chat.txt` must contain:
+
 - One CVE/GHSA/PYSEC ID per line.
 - Lines matching: `^(GHSA-[0-9a-z-]+|PYSEC-[0-9]{4}-[0-9]+|CVE-[0-9]{4}-[0-9]+)$`
 - Blank lines and `#` comment lines are ignored.


### PR DESCRIPTION
## Objective
Two **pre-existing failures on `main`** are blocking CI on every open AchaeanFleet PR (observed on dependabot PRs #690 and #686, which don't touch the affected files — the failures are inherited from main, which is why the auto-fix driver could produce no fixing commit).

## Root causes & fixes

### 1. buildx cache export fails the image build (blocks cap_drop + smoke-test)
`.github/workflows/ci.yml` set up buildx with `driver: docker` but the `Build achaean-base-node` / `Build achaean-claude` steps use `cache-to: type=gha,mode=max`. The GHA cache exporter is **not supported by the `docker` driver**:
```
ERROR: failed to build: Cache export is not supported for the docker driver.
##[error]buildx failed with: ...
```
The build fails ~4s in, so the dependent **`Validate claude cap_drop=ALL`** and **`Smoke Test AI Vessel Entrypoint`** steps never get a built image. Fix: switch to `driver: docker-container`, which supports `cache-to: type=gha` (and still works with `load: true`).

### 2. markdownlint MD032 (pre-existing)
`docs/runbooks/dependency-audit-allowlists.md:69,80` — lists not surrounded by blank lines. Added the blank lines.

## Verification
- `ci.yml` parses as valid YAML.
- markdownlint clean using the **CI-pinned** toolchain: `markdownlint-cli2 v0.18.1` / `markdownlint v0.38.0` (bundled by `markdownlint-cli2-action@v20.0.0`) with the repo's `.markdownlint.yaml` → `Summary: 0 error(s)`. (A newer local markdownlint flags MD060 on an unrelated table at line 9, but that rule isn't in the CI version and is out of scope.)
- Once merged, rebasing #690/#686 (and other open PRs) onto main should clear the buildx + markdownlint failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)