### PR TITLE
[Fix] Use docker driver for cap_drop job so base image resolves

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,10 +111,18 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.1.7
 
-      - name: Set up Docker Buildx (docker-container driver)
+      - name: Set up Docker Buildx (docker driver — loads image into daemon directly)
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd  # v4.0.0
         with:
-          driver: docker-container
+          # Must be the `docker` driver, NOT `docker-container`: the claude
+          # build below consumes achaean-base-node:latest via build-arg. The
+          # `docker-container` driver has an isolated image store and cannot
+          # see images built with `load: true` into the daemon, so it falls
+          # back to pulling docker.io/library/achaean-base-node and fails with
+          # "pull access denied". The `docker` driver shares the daemon store,
+          # so the loaded base image resolves locally. Mirrors the working
+          # build-vessels / smoke matrix. See #305 / drive-prs-green analysis.
+          driver: docker
 
       - name: Build achaean-base-node
         uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f  # v7.1.0


### PR DESCRIPTION
## Objective

Follow-up to #693. The `validate-claude-caps` job still uses `driver: docker-container`, which breaks base-image resolution and keeps the `Validate claude cap_drop=ALL` check red on `main` and on every dependabot PR.

## Root cause & fix

The achaean-claude build consumes `achaean-base-node:latest` via build-arg. The `docker-container` driver has an isolated image store and cannot see images built with `load: true` into the daemon, so it falls back to pulling `docker.io/library/achaean-base-node` → **`pull access denied, insufficient_scope`**.

→ Switch to `driver: docker` (daemon-shared store), matching the working `build-vessels` / smoke matrix where the identical two-step `load: true` pattern succeeds. The loaded base image then resolves locally.

The gha-cache removal from #693 stays — the `docker` driver can't export to `type=gha` either.

## Verification

- [ ] `Validate claude cap_drop=ALL` builds both images and runs the validation script (no `pull access denied`)
- [ ] `Build All Agent Images` rollup goes green

## Notes

Surfaced by a `drive_prs_green` ecosystem run. The base-image-resolution failure is exactly the trap the original diagnosis flagged for `docker-container`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)