### PR TITLE
[Fix] Repair hadolint suppressions (ignore→ignored) — unblock lint on main

### DIFF
--- a/.hadolint.yaml
+++ b/.hadolint.yaml
@@ -2,10 +2,15 @@
 #
 # Intentional suppressions — each rule is suppressed because the pattern
 # is reviewed and accepted for this repo.
+#
+# NOTE: the suppression key MUST be `ignored:` (hadolint >=2.x). The
+# misspelling `ignore:` is silently dropped, which voids EVERY suppression
+# below and leaks all findings into CI as errors — the lint job was red on
+# main for exactly that reason.
 
 failure-threshold: error
 
-ignore:
+ignored:
   # DL3008: apt packages not pinned to a specific version.
   # Intentional: base image digest acts as the version lock.
   - DL3008

--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -58,7 +58,7 @@ RUN npm install -g yarn@1.22.22
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN groupadd -g ${GROUP_ID} agent && \
-    useradd -m -u ${USER_ID} -g agent -s /bin/zsh agent && \
+    useradd -l -m -u ${USER_ID} -g agent -s /bin/zsh agent && \
     echo "agent ALL=(ALL) NOPASSWD: /usr/bin/tmux, /usr/bin/git" >> /etc/sudoers
 
 # Configure tmux

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -58,7 +58,7 @@ RUN npm install -g yarn@1.22.22
 ARG USER_ID=1000
 ARG GROUP_ID=1000
 RUN groupadd -g ${GROUP_ID} agent && \
-    useradd -m -u ${USER_ID} -g agent -s /bin/zsh agent && \
+    useradd -l -m -u ${USER_ID} -g agent -s /bin/zsh agent && \
     echo "agent ALL=(ALL) NOPASSWD: /usr/bin/tmux, /usr/bin/git" >> /etc/sudoers
 
 # Configure tmux
@@ -81,7 +81,7 @@ COPY bases/scripts/strip-setuid.sh /tmp/strip-setuid.sh
 RUN bash /tmp/strip-setuid.sh && rm /tmp/strip-setuid.sh
 
 # Upgrade pip (version pinned for reproducibility — issue #2)
-RUN pip install --upgrade "pip==26.0.1"
+RUN pip install --no-cache-dir --upgrade "pip==26.0.1"
 
 COPY bases/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
## Objective

The `Lint Dockerfiles and YAML` job has been red on `main` (and every PR). Fix it.

## Root cause

`.hadolint.yaml` used the suppression key **`ignore:`**, but hadolint >= 2.x reads **`ignored:`**. The misspelled key is silently dropped, which **voided every documented suppression** (DL3008, DL3015, DL3059, DL3016, DL3013, DL3006, DL4006, SC2312, SC2015). hadolint itself still exits 0 (those are warning/info level), but the `hadolint-action` surfaces every leaked finding as a `::error::` annotation and fails the step.

So the rules weren't "disabled" on purpose being ignored — they were *meant* to be suppressed (each has a reviewed rationale in the file), but the typo meant **none** of the suppressions applied.

## Fix

1. Rename `ignore:` → `ignored:` so the reviewed suppressions take effect; documented the gotcha inline.
2. Two findings were **never** in the suppression list (team intent = enforce), so fix the Dockerfiles instead of suppressing:
   - **DL3046** — add `-l` to `useradd` in `bases/Dockerfile.python` and `bases/Dockerfile.minimal` (prevents excessively large images for high UIDs).
   - **DL3042** — add `--no-cache-dir` to the pip upgrade in `bases/Dockerfile.python` (keeps the image lean).

## Verification

```
hadolint -c .hadolint.yaml --failure-threshold error <each of 11 Dockerfiles>
→ zero findings across all 11
```

Local hadolint is v2.14.0, matching CI's `ghcr.io/hadolint/hadolint:v2.14.0-debian`.

## Notes

Surfaced while fixing AchaeanFleet CI (#693, #694) during a `drive_prs_green` ecosystem cleanup. This was the last pre-existing red check on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)