### PR TITLE
fix(ci): replace || true suppression with diagnostic echo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -684,7 +684,7 @@ jobs:
           tar_file=$(find /tmp/base-image-achaean-base-minimal -name "*.tar" -type f | head -1)
           if [ -z "$tar_file" ]; then
             echo "ERROR: No tar file found in /tmp/base-image-achaean-base-minimal/"
-            ls -la /tmp/base-image-achaean-base-minimal/ || true
+            ls -la /tmp/base-image-achaean-base-minimal/ 2>&1 || echo "Directory listing failed (directory may not exist)"
             exit 1
           fi
           docker load -i "$tar_file"


### PR DESCRIPTION
## Summary

- Fixes the `forbid-suppressions` Required Check failure on main
- Replaces `|| true` on the diagnostic `ls` in the "Load base image" step (line 687) with `|| echo "Directory listing failed (directory may not exist)"` — preserves the informational intent without silently suppressing errors
- Only `.github/workflows/ci.yml` is modified

Fixes HomericIntelligence/Odysseus#280 (rule enforcement).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>