### PR TITLE
docs(readme): add standardized CI/CD badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # AchaeanFleet
 
+[![Build All Agent Images](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/ci.yml/badge.svg)](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/ci.yml)
+[![Security Scanning](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/security.yml/badge.svg)](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/security.yml)
+[![Shell Script Tests](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/shell-tests.yml/badge.svg)](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/shell-tests.yml)
+[![Release](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/release.yml/badge.svg)](https://github.com/HomericIntelligence/AchaeanFleet/actions/workflows/release.yml)
+
 Container infrastructure for the HomericIntelligence agent mesh.
 Builds OCI-compliant Docker images for every AI agent type.
 Agent provisioning lives in [Myrmidons](../Myrmidons).


### PR DESCRIPTION
Part of HomericIntelligence/Odysseus#352

Add CI/CD status badges (Build, Security Scanning, Shell Tests, Release) to the top of README.md, following the standardized badge format being rolled out across all HomericIntelligence ecosystem repos.

Generated with [Claude Code](https://claude.com/claude-code)