### PR TITLE
fix(ci): add CVE-2026-12151 (undici) to trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -261,3 +261,11 @@ CVE-2026-39825
 # Expires: 2026-08-27
 # Reviewer: @mvillmow  PR #658
 CVE-2026-39826
+
+# CVE-2026-12151
+# Category: npm
+# Rationale: undici 6.25.0 bundled in node:26-slim base image; fixed version 6.27.0 not yet available in current base image tag
+# Exploitability: low — DoS via WebSocket memory growth requires attacker-controlled WebSocket connections to the container
+# Expires: 2026-08-14
+# Reviewer: @mvillmow
+CVE-2026-12151


### PR DESCRIPTION
Fixes Build All Agent Images CI failure caused by Trivy CVE scan detecting CVE-2026-12151 in undici 6.25.0.

**Root cause:** undici 6.25.0 is bundled in the `node:26-slim` base image. Fixed version 6.27.0 is not yet available in the current pinned base image tag.

**Fix:** Add temporary suppression with 2026-08-14 expiry. The base image should be updated when a new node:26-slim release includes undici >= 6.27.0.