### PR TITLE
fix(ci): update pixi to v0.70.2 for lockfile v7 support

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -651,7 +651,7 @@ jobs:
         if: steps.detect.outputs.skip == 'false'
         uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f  # v0.10.0
         with:
-          pixi-version: v0.67.2
+          pixi-version: v0.70.2
           cache: true
       - name: pixi install (locked)
         if: steps.detect.outputs.skip == 'false'


### PR DESCRIPTION
CI pixi.lock uses lockfile format v7, but the CI workflow pins pixi v0.67.2 which only supports up to v6.

Update pixi-version from v0.67.2 to v0.70.2 in _required.yml to resolve the incompatibility.