### PR TITLE
fix(ci): resolve Trivy HIGH/CRITICAL findings in achaean-base-python

### DIFF
--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -48,8 +48,9 @@ RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     chmod +x /usr/local/lib/node_modules/npm/bin/npm-cli.js \
              /usr/local/lib/node_modules/npm/bin/npx-cli.js
 
-# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix)
-RUN npm install -g npm@11.13.0
+# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix) and
+# sigstore>=4.1.1 (CVE-2026-48815 fix)
+RUN npm install -g npm@11.18.0
 
 # Install Yarn
 RUN npm install -g yarn@1.22.22

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -24,8 +24,9 @@ LABEL org.opencontainers.image.version=${VERSION}
 
 USER root
 
-# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix)
-RUN npm install -g npm@11.13.0
+# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix) and
+# sigstore>=4.1.1 (CVE-2026-48815 fix)
+RUN npm install -g npm@11.18.0
 
 # Install system dependencies and apply security patches
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -48,8 +48,9 @@ RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     chmod +x /usr/local/lib/node_modules/npm/bin/npm-cli.js \
              /usr/local/lib/node_modules/npm/bin/npx-cli.js
 
-# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix)
-RUN npm install -g npm@11.13.0
+# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix) and
+# sigstore>=4.1.1 (CVE-2026-48815 fix)
+RUN npm install -g npm@11.18.0
 
 # Install Yarn
 RUN npm install -g yarn@1.22.22


### PR DESCRIPTION
## Failing workflow

**Build All Agent Images** → job **Build Base Images (achaean-base-python, bases/Dockerfile.python)**
was red on `main` (e.g. run [29238778218](https://github.com/HomericIntelligence/AchaeanFleet/actions/runs/29238778218)). The image builds fine; the `aquasecurity/trivy-action` step
(`severity: HIGH,CRITICAL`, `ignore-unfixed: true`) then exits 1:

```
Node.js (node-pkg)
==================
Total: 1 (HIGH: 1, CRITICAL: 0)

┌─────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬───────────────┬───────────────────────────────────────────────────────────┐
│         Library         │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │                           Title                           │
├─────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼───────────────┼───────────────────────────────────────────────────────────┤
│ sigstore (package.json) │ CVE-2026-48815 │ HIGH     │ fixed  │ 4.1.0             │ 4.1.1         │ sigstore's `certificateOIDs` verification constraints are │
│                         │                │          │        │                   │               │ silently dropped and never enforced                       │
│                         │                │          │        │                   │               │ https://avd.aquasec.com/nvd/cve-2026-48815                │
└─────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴───────────────┴───────────────────────────────────────────────────────────┘
##[error]Process completed with exit code 1.
```

The same finding also hit `achaean-base-node` and `achaean-base-minimal` in the same run.

## Root cause

All three base Dockerfiles pin npm via `RUN npm install -g npm@11.13.0` (added to pick up a
`picomatch>=4.0.4` fix for CVE-2026-33671). npm 11.13.0 bundles `sigstore@4.1.0`, which is
vulnerable to CVE-2026-48815. The upstream `node:26-slim` base image itself already ships a
newer npm (11.17.0, with `sigstore@4.1.1`), but our explicit reinstall step downgrades it back
to the vulnerable pin.

## Fix

Bump the pin to `npm@11.18.0` (latest 11.x release) in `bases/Dockerfile.python`,
`bases/Dockerfile.node`, and `bases/Dockerfile.minimal`. Verified locally that 11.18.0 bundles:

- `sigstore@4.1.1` — fixes CVE-2026-48815
- `picomatch@4.0.4` (via `tinyglobby`) — retains the original CVE-2026-33671 fix

No `.trivyignore` entry was needed since a patched version is available (per `SECURITY.md`'s
"Suppression is a last resort. Prefer bumping ... first" policy).

## Verification

1. Built `node:26-slim@sha256:a1d9d67...` standalone and confirmed the base image already bundles
   npm 11.17.0 / sigstore 4.1.1, but that `npm install -g npm@11.13.0` on top of it reintroduces
   sigstore 4.1.0.
2. Confirmed `npm install -g npm@11.18.0` yields sigstore 4.1.1 + picomatch 4.0.4.
3. Built `achaean-base-python` locally from this branch (`docker build`, CPU-capped to 2 cores)
   and re-scanned with:
   ```
   docker run --rm -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image \
     --severity HIGH,CRITICAL --ignore-unfixed achaean-base-python:trivytest
   ```
   Result: zero HIGH/CRITICAL findings (previously 1), exit code 0 — matches the CI gate's config.

## Files changed

- `bases/Dockerfile.python`
- `bases/Dockerfile.node`
- `bases/Dockerfile.minimal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)