### PR TITLE
fix(security): suppress CVE-2026-39822 (Go stdlib os.Root) in gh/yq vessel binaries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,10 +683,10 @@ jobs:
       - name: Load base image into Docker daemon
         run: |
           set -euo pipefail
-          tar_file=$(find /tmp/base-image-achaean-base-minimal -name "*.tar" -type f | head -1)
+          tar_file=$(find /tmp -maxdepth 1 -name "*.tar" -type f | head -1)
           if [ -z "$tar_file" ]; then
-            echo "ERROR: No tar file found in /tmp/base-image-achaean-base-minimal/"
-            ls -la /tmp/base-image-achaean-base-minimal/ 2>&1 || echo "Directory listing failed (directory may not exist)"
+            echo "ERROR: No tar file found in /tmp"
+            ls -la /tmp/ 2>&1 || echo "Directory listing failed (directory may not exist)"
             exit 1
           fi
           docker load -i "$tar_file"
@@ -757,7 +757,7 @@ jobs:
       - name: Load base image into Docker daemon
         run: |
           set -euo pipefail
-          tar_file=$(find /tmp/base-image-${{ matrix.vessel.base }} -name "*.tar" -type f | head -1)
+          tar_file=$(find /tmp -maxdepth 1 -name "*.tar" -type f | head -1)
           IMAGE_ID=$(docker load -i "$tar_file" | tail -1 | awk '{print $NF}')
           docker tag "$IMAGE_ID" "${{ matrix.vessel.base }}:latest"
 
@@ -1177,7 +1177,7 @@ jobs:
       - name: Load base image into Docker daemon
         run: |
           set -euo pipefail
-          tar_file=$(find /tmp/base-image-${{ matrix.vessel.base }} -name "*.tar" -type f | head -1)
+          tar_file=$(find /tmp -maxdepth 1 -name "*.tar" -type f | head -1)
           docker load -i "$tar_file"
 
       - name: Verify loaded base image integrity
@@ -1192,7 +1192,7 @@ jobs:
       - name: Verify vessel artifact is non-empty
         shell: bash
         run: |
-          if ! find /tmp/base-image-${{ matrix.vessel.base }} -name "*.tar" -type f | grep -q .; then
+          if ! find /tmp -maxdepth 1 -name "*.tar" -type f | grep -q .; then
             echo "ERROR: base image tarball missing or empty"; exit 1
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -786,7 +786,7 @@ jobs:
             BASE_IMAGE=${{ matrix.vessel.base }}:latest
             IMAGE_VERSION=git-${{ env.SHORT_SHA }}
             GOOSE_VERSION=1.31.1
-            YQ_VERSION=v4.53.2
+            YQ_VERSION=v4.53.3
             OPENCODE_VERSION=v1.4.3
           push: false
           load: true
@@ -1036,7 +1036,7 @@ jobs:
           build-args: |
             BASE_IMAGE=${{ matrix.vessel.base }}:latest
             GOOSE_VERSION=1.31.1
-            YQ_VERSION=v4.53.2
+            YQ_VERSION=v4.53.3
             OPENCODE_VERSION=v1.4.3
           push: false
           load: true

--- a/.trivyignore
+++ b/.trivyignore
@@ -272,7 +272,7 @@ CVE-2026-12151
 
 # CVE-2026-39822
 # Category: other
-# Rationale: Go stdlib os.Root symlink-following fix exists (Go 1.25.12 / 1.26.5) but no upstream binary rebuilt with a patched toolchain is available yet: latest GitHub CLI release v2.96.0 (2026-07-02, /usr/bin/gh in achaean-claude) is built with Go 1.26.4, and yq v4.53.2 (/usr/local/bin/yq in achaean-worker) is built with Go 1.26.2. Tracking removal in issue #720.
+# Rationale: Go stdlib os.Root symlink-following fix exists (Go 1.25.12 / 1.26.5) but no upstream binary rebuilt with a patched toolchain is available yet: latest GitHub CLI release v2.96.0 (2026-07-02, /usr/bin/gh in achaean-claude) is built with Go 1.26.4, and yq v4.53.3 (2026-06-06, /usr/local/bin/yq in achaean-worker) is also built with Go 1.26.4 — both predate the 1.26.5 fix. Tracking removal in issue #720.
 # Exploitability: low — os.Root traversal requires an attacker able to pre-place symlinks in directories the binary opens via os.Root; gh and yq run as developer CLIs inside the vessel with no attacker-controlled filesystem input path in this container's runtime context.
 # Expires: 2026-10-12
 # Reviewer: @mvillmow  PR #721

--- a/.trivyignore
+++ b/.trivyignore
@@ -269,3 +269,11 @@ CVE-2026-39826
 # Expires: 2026-08-14
 # Reviewer: @mvillmow
 CVE-2026-12151
+
+# CVE-2026-39822
+# Category: other
+# Rationale: Go stdlib os.Root symlink-following fix exists (Go 1.25.12 / 1.26.5) but no upstream binary rebuilt with a patched toolchain is available yet: latest GitHub CLI release v2.96.0 (2026-07-02, /usr/bin/gh in achaean-claude) is built with Go 1.26.4, and yq v4.53.2 (/usr/local/bin/yq in achaean-worker) is built with Go 1.26.2. Tracking removal in issue #720.
+# Exploitability: low — os.Root traversal requires an attacker able to pre-place symlinks in directories the binary opens via os.Root; gh and yq run as developer CLIs inside the vessel with no attacker-controlled filesystem input path in this container's runtime context.
+# Expires: 2026-10-12
+# Reviewer: @mvillmow  PR #721
+CVE-2026-39822

--- a/bases/Dockerfile.minimal
+++ b/bases/Dockerfile.minimal
@@ -48,8 +48,9 @@ RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     chmod +x /usr/local/lib/node_modules/npm/bin/npm-cli.js \
              /usr/local/lib/node_modules/npm/bin/npx-cli.js
 
-# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix)
-RUN npm install -g npm@11.13.0
+# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix) and
+# sigstore>=4.1.1 (CVE-2026-48815 fix)
+RUN npm install -g npm@11.18.0
 
 # Install Yarn
 RUN npm install -g yarn@1.22.22

--- a/bases/Dockerfile.node
+++ b/bases/Dockerfile.node
@@ -24,8 +24,9 @@ LABEL org.opencontainers.image.version=${VERSION}
 
 USER root
 
-# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix)
-RUN npm install -g npm@11.13.0
+# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix) and
+# sigstore>=4.1.1 (CVE-2026-48815 fix)
+RUN npm install -g npm@11.18.0
 
 # Install system dependencies and apply security patches
 RUN apt-get update && apt-get upgrade -y && apt-get install -y \

--- a/bases/Dockerfile.python
+++ b/bases/Dockerfile.python
@@ -48,8 +48,9 @@ RUN ln -sf ../lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm && \
     chmod +x /usr/local/lib/node_modules/npm/bin/npm-cli.js \
              /usr/local/lib/node_modules/npm/bin/npx-cli.js
 
-# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix)
-RUN npm install -g npm@11.13.0
+# Upgrade npm to get picomatch>=4.0.4 (CVE-2026-33671 fix) and
+# sigstore>=4.1.1 (CVE-2026-48815 fix)
+RUN npm install -g npm@11.18.0
 
 # Install Yarn
 RUN npm install -g yarn@1.22.22

--- a/versions.yml
+++ b/versions.yml
@@ -73,6 +73,15 @@ tools:
         asset: "yq_linux_arm64"
         sha256: "578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
 
+  npm:
+    version: "11.18.0"
+    source: "https://registry.npmjs.org/npm/-/npm-11.18.0.tgz"
+    used_by:
+      - bases/Dockerfile.minimal
+      - bases/Dockerfile.node
+      - bases/Dockerfile.python
+    checksums: null  # installed via npm; integrity enforced by npm registry
+
   yarn:
     version: "1.22.22"
     source: "https://registry.npmjs.org/yarn/-/yarn-1.22.22.tgz"

--- a/versions.yml
+++ b/versions.yml
@@ -61,17 +61,17 @@ tools:
         sha256: "4cbf32f4c31da7dae14712b65aadbce6acfa1a7a85bee986a2ce4eaaed4eb5c8"
 
   yq:
-    version: "v4.53.2"
-    source: "https://github.com/mikefarah/yq/releases/tag/v4.53.2"
+    version: "v4.53.3"
+    source: "https://github.com/mikefarah/yq/releases/tag/v4.53.3"
     used_by:
       - vessels/worker/Dockerfile
     checksums:
       amd64:
         asset: "yq_linux_amd64"
-        sha256: "d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b"
+        sha256: "fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4"
       arm64:
         asset: "yq_linux_arm64"
-        sha256: "03061b2a50c7a498de2bbb92d7cb078ce433011f085a4994117c2726be4106ea"
+        sha256: "578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea"
 
   yarn:
     version: "1.22.22"

--- a/vessels/worker/Dockerfile
+++ b/vessels/worker/Dockerfile
@@ -14,8 +14,8 @@ LABEL org.opencontainers.image.description="Shell worker vessel — no AI tool, 
 ARG BUILD_DATE
 ARG VCS_REF
 ARG VERSION
-ARG YQ_VERSION=v4.53.2
-ENV YQ_VERSION=v4.53.2
+ARG YQ_VERSION=v4.53.3
+ENV YQ_VERSION=v4.53.3
 ARG GIT_SHA=unknown
 LABEL org.opencontainers.image.created=${BUILD_DATE}
 LABEL org.opencontainers.image.revision=${VCS_REF}
@@ -27,8 +27,8 @@ USER root
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 ARG TARGETARCH=amd64
-ARG YQ_AMD64_SHA256=d56bf5c6819e8e696340c312bd70f849dc1678a7cda9c2ad63eebd906371d56b
-ARG YQ_ARM64_SHA256=03061b2a50c7a498de2bbb92d7cb078ce433011f085a4994117c2726be4106ea
+ARG YQ_AMD64_SHA256=fa52a4e758c63d38299163fbdd1edfb4c4963247918bf9c1c5d31d84789eded4
+ARG YQ_ARM64_SHA256=578648e463a11c1b6db6010cbf41eafed6bee79466fcffa1bb446672cf7945ea
 
 # Install required tools — failures here are fatal
 RUN apt-get update && \


### PR DESCRIPTION
## Summary

Third and final blocker for restoring green `main`. Once #716 (Trivy sigstore fix) and #718 (download-artifact v4 path fix) are in, the vessel Trivy scans get far enough to flag a brand-new HIGH finding: **CVE-2026-39822** (Go stdlib `os.Root` symlink-following directory traversal, fixed in Go 1.25.12 / 1.26.5) in:

- `/usr/bin/gh` in `achaean-claude` — the **latest** GitHub CLI release v2.96.0 (2026-07-02) is built with Go 1.26.4
- `/usr/local/bin/yq` in `achaean-worker` — yq v4.53.2 is built with Go 1.26.2 (same binary already has suppressions for CVE-2026-39823/39825/39826 from PR #658)

Observed on PR #719's run: `Build Vessel Images (achaean-claude)` failed at "Trivy scan vessel image" (https://github.com/HomericIntelligence/AchaeanFleet/actions/runs/29343751483/job/87124441335); the other 3 "failures" were fail-fast cancellations.

## Why suppression (not a bump)

Per SECURITY.md's CVE Suppression Policy checklist:
- `ignore-unfixed: true` does not cover it — the Go fix exists, so Trivy reports status `fixed`.
- No upstream `gh` or `yq` release built with a patched Go toolchain exists yet (v2.96.0 is the newest gh release; verified against `cli/cli` releases).
- Exploitability is low: `os.Root` traversal requires an attacker able to pre-place symlinks in directories the binary opens via `os.Root`; gh/yq run as developer CLIs inside the vessel with no attacker-controlled filesystem input path.

Entry follows the required 6-field format with a 90-day expiry (2026-10-12). Removal (bump gh/yq once rebuilt upstream) is tracked in #720.

## Stack

Branched from #718 (`fix/ci-base-image-artifact-path`) so CI on this PR proves the complete fix chain. **Landing order: #716 → #718 → this PR → #719.** The diff vs main therefore includes #716/#718's commits until they merge, after which it collapses to the single `.trivyignore` entry.

Suppression-removal tracking issue: #720 (stays open until the entry is deleted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update (2026-07-16): yq bumped to v4.53.3 — clears 5 additional worker HIGHs

The first CI run on this PR surfaced **five more HIGH findings** in `achaean-worker`'s yq v4.53.2 binary (run 29346518170) that the CVE-2026-39822 suppression does not cover:

- `golang.org/x/net` v0.52.0: CVE-2026-25681, CVE-2026-27136, CVE-2026-39821 (fixed in x/net 0.55.0)
- Go stdlib 1.26.2: CVE-2026-27145, CVE-2026-42504 (fixed in Go 1.26.4)

yq **v4.53.3** (2026-06-06) is built with **Go 1.26.4 + x/net v0.55.0**, clearing all five — so this PR now bumps yq instead of suppressing them (`vessels/worker/Dockerfile`, `versions.yml`, both `ci.yml` build-args; checksums verified against the upstream release manifest). CVE-2026-39822 (fixed only in Go 1.26.5) still applies to both gh v2.96.0 and yq v4.53.3, so the `.trivyignore` entry stays; its rationale is updated to cite the new yq version.
