### PR TITLE
ci: fast (<5 min) merge-queue smoke gate

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -8,8 +8,6 @@ on:
     branches: [main]
   push:
     branches: [main]
-  merge_group:
-    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:
@@ -707,3 +705,44 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - name: Run symlink check
         run: bash scripts/check-symlinks.sh
+
+  # Single aggregate context over every gating job above. On pull_request/push
+  # this summarizes the full required matrix; on merge_group events the fast
+  # merge-queue-smoke.yml workflow produces the same `merge-gate` context
+  # (this workflow no longer triggers on merge_group), so exactly one
+  # `merge-gate` check-run exists per event.
+  merge-gate:
+    name: merge-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    if: always()
+    needs:
+      - forbid-suppressions
+      - lint
+      - unit-tests
+      - integration-tests
+      - security-dependency-scan
+      - security-secrets-scan
+      - build
+      - test
+      - package
+      - install
+      - release
+      - schema-validation
+      - deps-version-sync
+      - markdownlint
+      - pixi-check
+      - justfile-check
+      - symlink-check
+    steps:
+      - name: All required jobs succeeded
+        env:
+          RESULTS: ${{ toJson(needs) }}
+        run: |
+          set -euo pipefail
+          echo "$RESULTS" | jq -e '
+            to_entries
+            | map(select(.value.result != "success"))
+            | if length == 0 then true
+              else (map("\(.key): \(.value.result)") | join(", ") | error)
+              end'

--- a/.github/workflows/merge-queue-smoke.yml
+++ b/.github/workflows/merge-queue-smoke.yml
@@ -1,0 +1,58 @@
+name: Merge Queue Smoke
+
+# Fast merge-queue gate. The full required matrix (_required.yml) runs on
+# every pull_request and on push to main; merge_group re-validation is this
+# single fast job, so a queued merge occupies one runner slot for < 5 min
+# instead of re-running the whole matrix. The job is named `merge-gate` to
+# produce the same status context as the PR-side aggregator in _required.yml.
+
+on:
+  merge_group:
+    types: [checks_requested]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mq-smoke-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  merge-gate:
+    name: merge-gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Install yamllint
+        run: pip install --quiet yamllint
+
+      - name: Lint YAML (yamllint)
+        run: |
+          # Use repo's own config if present, otherwise relaxed defaults
+          if [ -f .yamllint.yaml ] || [ -f .yamllint.yml ] || [ -f .yamllint ]; then
+            yamllint .
+          else
+            yamllint -d relaxed .
+          fi
+
+      - name: Run symlink check
+        run: bash scripts/check-symlinks.sh
+
+      - name: Syntax-check shell test/helper scripts
+        run: |
+          set -euo pipefail
+          # bash -n only understands POSIX/bash syntax. .bats files use the
+          # BATS DSL (@test { ... }) which is NOT valid bash, so they are
+          # excluded here (the bats runner validates them in unit-tests).
+          mapfile -t sh_files < <(find tests scripts \
+            \( -name "*.sh" -o -name "*.bash" \) \
+            -type f 2>/dev/null | sort)
+          if [ "${#sh_files[@]}" -eq 0 ]; then
+            echo "No shell scripts to syntax-check"
+            exit 0
+          fi
+          for f in "${sh_files[@]}"; do
+            bash -n "$f" && echo "OK: $f"
+          done


### PR DESCRIPTION
## Diagnosis

merge_group events currently re-trigger the full required workflow (`_required.yml`, 17 jobs). Each job waits 8-16+ min for a self-hosted runner slot, so a single queued merge consumes many runner slots and takes 70-90 minutes of wall time before the queue can merge.

## Design

- `_required.yml` no longer triggers on `merge_group`. Its `pull_request`, `push: branches: [main]`, and `workflow_dispatch` triggers and every existing job are unchanged — PR testing is exactly as before.
- A new `merge-gate` aggregator job (`if: always()`, `needs:` all 17 gating jobs, jq assertion that every result is `success`) gives PRs a single canonical status context covering every required check (`lint`, `unit-tests`, `integration-tests`, `security/dependency-scan`, `security/secrets-scan`, `build`, `schema-validation`, `deps/version-sync`, `test`, `package`, `install`, `release`).
- New `.github/workflows/merge-queue-smoke.yml` triggers ONLY on `merge_group` and runs a single job also named `merge-gate` (one runner slot, `timeout-minutes: 5`) with real fast validation borrowed from the existing quick jobs: yamllint with the repo config, `scripts/check-symlinks.sh`, and `bash -n` syntax checks over `tests/` and `scripts/` shell scripts.
- Because the full workflow no longer listens on `merge_group` and the smoke workflow listens only on `merge_group`, exactly one `merge-gate` check-run exists per event.
- All action refs are the same pinned SHAs already used in this repo.

## Post-merge ruleset rollout (REQUIRED)

After merge, ruleset `required_status_checks` must be replaced with the single context `merge-gate` and `min_entries_to_merge_wait_minutes` set to 0; until then the queue must not be used because `merge_group` no longer produces the old contexts.

Affected ruleset: `homeric-main-baseline` (id 15556484).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
