### PR TITLE
fix(ci): align merge-queue readiness test with merge-gate

### DIFF
--- a/tests/test_merge_queue_readiness.py
+++ b/tests/test_merge_queue_readiness.py
@@ -28,7 +28,8 @@ REQUIRED_CONTEXTS = {
     "unit-tests",
 }
 
-REQUIRED_EVENTS = frozenset({"pull_request", "push", "merge_group"})
+FULL_REQUIRED_EVENTS = frozenset({"pull_request", "push"})
+MERGE_QUEUE_SMOKE_WORKFLOW = WORKFLOWS_DIR / "merge-queue-smoke.yml"
 
 EVENT_NAME_COMPARISON = re.compile(
     r"\A\s*github\.event_name\s*(?P<operator>==|!=)\s*(['\"])(?P<event>[^'\"]+)\2\s*\Z"
@@ -61,8 +62,8 @@ def _required_context_producers(
     return producers
 
 
-def _job_condition_allows_required_events(condition: str) -> bool:
-    """Return whether a condition is explicitly safe for every required event.
+def _job_condition_allows_full_required_events(condition: str) -> bool:
+    """Return whether a condition is safe for every full-matrix event.
 
     This intentionally accepts only a standalone direct comparison. GitHub
     expressions involving any other context, function, output, or boolean
@@ -73,8 +74,8 @@ def _job_condition_allows_required_events(condition: str) -> bool:
         return False
 
     if comparison["operator"] == "==":
-        return REQUIRED_EVENTS <= {comparison["event"]}
-    return comparison["event"] not in REQUIRED_EVENTS
+        return FULL_REQUIRED_EVENTS <= {comparison["event"]}
+    return comparison["event"] not in FULL_REQUIRED_EVENTS
 
 
 @pytest.mark.parametrize(
@@ -102,7 +103,7 @@ def _job_condition_allows_required_events(condition: str) -> bool:
         ),
         pytest.param(
             "github.event_name != 'merge_group'",
-            False,
+            True,
             id="direct-merge-group-exclusion",
         ),
         pytest.param(
@@ -133,12 +134,12 @@ def _job_condition_allows_required_events(condition: str) -> bool:
         ),
     ],
 )
-def test_job_condition_allows_all_required_events_is_fail_closed(
+def test_job_condition_allows_full_required_events_is_fail_closed(
     condition: str,
     expected: bool,
 ) -> None:
-    """Only direct event checks proven safe for all required events may pass."""
-    assert _job_condition_allows_required_events(condition) is expected
+    """Only direct event checks proven safe for PR and push may pass."""
+    assert _job_condition_allows_full_required_events(condition) is expected
 
 
 def test_every_required_context_has_a_workflow_producer() -> None:
@@ -197,11 +198,11 @@ def test_required_context_producer_discovery_retains_job_conditions() -> None:
         }
     ),
 )
-def test_required_job_condition_cannot_exclude_required_events(
+def test_required_job_condition_cannot_exclude_full_required_events(
     monkeypatch: pytest.MonkeyPatch,
     condition: str,
 ) -> None:
-    """A workflow trigger cannot compensate for a job condition that skips a required event."""
+    """A trigger cannot compensate for a job condition that skips PR or push."""
     path = Path("conditioned-required-check.yml")
     workflows = {
         path: {
@@ -221,7 +222,7 @@ def test_required_job_condition_cannot_exclude_required_events(
     monkeypatch.setitem(globals(), "_load_workflows", lambda: workflows)
 
     with pytest.raises(AssertionError):
-        test_required_context_workflows_support_merge_queue_and_existing_events()
+        test_required_context_workflows_and_merge_queue_smoke_are_disjoint()
 
 
 def test_required_context_workflow_graph_rejects_duplicate_integration_tests_producer(
@@ -249,11 +250,11 @@ def test_required_context_workflow_graph_rejects_duplicate_integration_tests_pro
     monkeypatch.setitem(globals(), "_load_workflows", lambda: duplicate_workflows)
 
     with pytest.raises(AssertionError, match="duplicate.*integration-tests"):
-        test_required_context_workflows_support_merge_queue_and_existing_events()
+        test_required_context_workflows_and_merge_queue_smoke_are_disjoint()
 
 
-def test_required_context_workflows_support_merge_queue_and_existing_events() -> None:
-    """Every required-context producer must run for PRs, main pushes, and queue groups."""
+def test_required_context_workflows_and_merge_queue_smoke_are_disjoint() -> None:
+    """Keep the full matrix on PR/push and one fast gate on queue groups."""
     workflows = _load_workflows()
     producers = _required_context_producers(workflows)
 
@@ -278,9 +279,9 @@ def test_required_context_workflows_support_merge_queue_and_existing_events() ->
             assert isinstance(condition, str), (
                 f"Expected string condition for {job_id} in {path}"
             )
-            assert _job_condition_allows_required_events(condition), (
+            assert _job_condition_allows_full_required_events(condition), (
                 f"{path} job {job_id} ({context}) condition {condition!r} "
-                "must allow pull_request, push, and merge_group events"
+                "must allow pull_request and push events"
             )
 
     producer_paths = {
@@ -298,6 +299,26 @@ def test_required_context_workflows_support_merge_queue_and_existing_events() ->
         assert triggers.get("push", {}).get("branches") == ["main"], (
             f"{path} must preserve push coverage for main"
         )
-        assert triggers.get("merge_group", {}).get("types") == ["checks_requested"], (
-            f"{path} must run required contexts for merge_group/checks_requested"
+        assert "merge_group" not in triggers, (
+            f"{path} must leave merge_group to the fast merge-gate workflow"
         )
+
+    smoke = workflows[MERGE_QUEUE_SMOKE_WORKFLOW]
+    smoke_triggers = smoke.get("on")
+    assert isinstance(smoke_triggers, dict), "Expected an event mapping in merge-queue smoke"
+    assert smoke_triggers.get("merge_group", {}).get("types") == ["checks_requested"], (
+        "merge-queue smoke must run for merge_group/checks_requested"
+    )
+    assert "pull_request" not in smoke_triggers
+    assert "push" not in smoke_triggers
+
+    merge_gate_producers = [
+        (path, job_id)
+        for path, workflow in workflows.items()
+        if "merge_group" in workflow.get("on", {})
+        for job_id, job in workflow.get("jobs", {}).items()
+        if job.get("name", job_id) == "merge-gate"
+    ]
+    assert merge_gate_producers == [(MERGE_QUEUE_SMOKE_WORKFLOW, "merge-gate")], (
+        "merge_group must emit exactly one merge-gate context"
+    )


### PR DESCRIPTION
## Summary

Align the executable readiness guard with the merged fast merge-queue design: full required contexts run for pull requests and main pushes, while merge-group events emit exactly one merge-gate from the smoke workflow.

## Verification

- uv run pytest tests/test_merge_queue_readiness.py -q --tb=short
- uv run pytest tests -q --tb=short

Closes #731