### PR TITLE
fix(ci): run required checks for merge groups

### DIFF
--- a/.github/workflows/_required.yml
+++ b/.github/workflows/_required.yml
@@ -8,6 +8,8 @@ on:
     branches: [main]
   push:
     branches: [main]
+  merge_group:
+    types: [checks_requested]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- add the required `merge_group` / `checks_requested` trigger to the protected
  required-context workflow;
- preserve existing pull-request, push-to-main, and manual-dispatch triggers;
- restore the clean AchaeanFleet baseline required by the Hephaestus
  repository-wide UV pre-PR gate.

## Plan and verification

The red readiness regression already specified the required trigger shape. This
PR applies that minimal workflow-only change and proves it with:

```text
uv run pytest tests -q --tb=short
# 280 passed, 1 skipped

uv run pre-commit run --files .github/workflows/_required.yml
# passed
```

Closes #733
